### PR TITLE
APIの追加とPropertiesの修正

### DIFF
--- a/config/togosite.config.json
+++ b/config/togosite.config.json
@@ -275,14 +275,14 @@
     "properties": [
       {
         "propertyId": "atc_classification_pubchem",
-        "label": "ATC classification (PubChem)",
+        "label": "PubChem ATC classification",
         "description": "Anatomical Therapeutic Chemical (ATC) Classification in PubChem",
         "data": "https://integbio.jp/togosite/sparqlist/api/atc_classification_haschild",
         "primaryKey": "pubchem_compound"
       },
       {
         "propertyId": "atc_classification_pubchem_chembl",
-        "label": "ATC classification",
+        "label": "Chembl ATC classification",
         "description": "Anatomical Therapeutic Chemical (ATC) Classification in ChEMBL",
         "data": "https://integbio.jp/togosite/sparqlist/api/atcClassificationChEMBL",
         "primaryKey": "pubchem_compound"

--- a/config/togosite.config.json
+++ b/config/togosite.config.json
@@ -274,16 +274,23 @@
     "togoKey": "chembl_compound",
     "properties": [
       {
-        "propertyId": "atc_classification",
-        "label": "ATC classification",
-        "description": "Anatomical Therapeutic Chemical (ATC) Classification",
+        "propertyId": "atc_classification_pubchem",
+        "label": "ATC classification (PubChem)",
+        "description": "Anatomical Therapeutic Chemical (ATC) Classification in PubChem",
         "data": "https://integbio.jp/togosite/sparqlist/api/atc_classification_haschild",
         "primaryKey": "pubchem_compound"
       },
       {
+        "propertyId": "atc_classification_pubchem_chembl",
+        "label": "ATC classification",
+        "description": "Anatomical Therapeutic Chemical (ATC) Classification in ChEMBL",
+        "data": "https://integbio.jp/togosite/sparqlist/api/atcClassificationChEMBL",
+        "primaryKey": "pubchem_compound"
+      },
+      {
         "propertyId": "chembl_mesh",
-        "label": "MeSH diseases category",
-        "description": "MeSH diseases category",
+        "label": "Drug indication (MeSH)",
+        "description": "Drug indications in MeSH categories",
         "data": "https://integbio.jp/togosite/sparqlist/api/chembl_mesh",
         "primaryKey": "chembl_compound"
       },


### PR DESCRIPTION
１．ChEMBLをATCで分類するAPIを追加しました。
https://integbio.jp/togosite/sparqlist/atcClassificationChEMBL
２．これに伴い、従来のATCで分類(PubChemベース)と区別するためpropertyを変更しました。
３．chembl_meshのpropertyがわかりにくいため変更しました。