### PR TITLE
Created mesh_descriptor.hbs (MeSH Descriptor UID summary)

### DIFF
--- a/metastanza/mesh_descriptor.hbs
+++ b/metastanza/mesh_descriptor.hbs
@@ -2,7 +2,7 @@
 <h2>MeSH Descriptor {{id}}</h2>
 <script type="module" src="https://togostanza.github.io/metastanza/hash-table.js" async></script>
 <togostanza-hash-table
-  data-url="https://integbio.jp/togosite/sparqlist/api/mesh_descriptor?queryId&#x3D;{{id}}"
+  data-url="https://integbio.jp/togosite/sparqlist/api/mesh_descriptor?queryId={{id}}"
   data-type="json"
   width="800"
   height="400"

--- a/metastanza/mesh_descriptor.hbs
+++ b/metastanza/mesh_descriptor.hbs
@@ -1,0 +1,14 @@
+<script type="module" src="https://togostanza.github.io/metastanza/hash-table.js" async></script>
+<h2>MeSH Descriptor {{id}}</h2>
+<script type="module" src="https://togostanza.github.io/metastanza/hash-table.js" async></script>
+<togostanza-hash-table
+  data-url="https://integbio.jp/togosite/sparqlist/api/mesh_descriptor?queryId&#x3D;{{id}}"
+  data-type="json"
+  width="800"
+  height="400"
+  padding="0"
+  columns="[{&quot;id&quot;: &quot;id&quot;, &quot;label&quot;: &quot;MeSH UID&quot;},
+            {&quot;id&quot;: &quot;label&quot;}, {&quot;id&quot;: &quot;scope_note&quot;},
+            {&quot;id&quot;: &quot;tree_numbers&quot;}]"
+  format-key="true"
+></togostanza-hash-table>


### PR DESCRIPTION
他の皆さんが書かれたソースにある
queryId={{id}}
のところが
queryId&#x3D;{{id}}
になっていますが、=に戻すとブラウザ(Windows10上のChrome) で表示されなくなりましたのでそのままにしてあります