### PR TITLE
Update togosite.config.json

### DIFF
--- a/config/togosite.config.json
+++ b/config/togosite.config.json
@@ -292,7 +292,7 @@
         "label": "Chembl ATC classification",
         "description": "Anatomical Therapeutic Chemical (ATC) Classification in ChEMBL",
         "data": "https://integbio.jp/togosite/sparqlist/api/atcClassificationChEMBL",
-        "primaryKey": "pubchem_compound"
+        "primaryKey": "chembl_compound"
       },
       {
         "propertyId": "chembl_mesh",


### PR DESCRIPTION
"atc_classification_pubchem_chembl"はchemblを検索対象にしているのでprimaryKeyはchembl_compoundではないかと思いますが、いかがでしょうか。