### PR TITLE
template for multiple disease entries

### DIFF
--- a/config/togosite-human/templates/disease.hbs
+++ b/config/togosite-human/templates/disease.hbs
@@ -57,10 +57,16 @@
 
   const metastanzaDiv = document.getElementById("metastanza");
   const dataUrl = (id, type) => dataUrlEndpoint + '?id=' + id + '&type=' + type;
+  const titleDict = {
+    'mondo': 'Mondo',
+    'nando': 'NANDO',
+    'hp': 'HP',
+    'mesh': 'MeSH'
+  };
 
   const addHeader = (id, type) => {
     const header = document.createElement('h2');
-    const headerText = document.createTextNode(type + ': ' + id);
+    const headerText = document.createTextNode(titleDict[type] + ': ' + id);
     header.appendChild(headerText);
     metastanzaDiv.appendChild(header);
   }

--- a/config/togosite-human/templates/disease.hbs
+++ b/config/togosite-human/templates/disease.hbs
@@ -1,3 +1,23 @@
+<div id="metastanza">
+<script>
+  const metastanzaDiv = document.getElementById("metastanza");
+
+  const response = await fetch("https://integbio.jp/togosite/sparqlist/api/disease_id_converter?id={{id}}");
+  const idObjs = await response.json();
+
+  for (const idObj of idObjs) {
+    const hashTable = document.createElement('togostanza-hash-table');
+    hashTable.setAttribute('data-url','https://integbio.jp/togosite/sparqlist/api/disease_hpo_details?id=' + idObj.id + '&type=' idObj.type)
+    hashTable.setAttribute('data-type','json')
+    hashTable.setAttribute('width','800')
+    hashTable.setAttribute('height','400')
+    hashTable.setAttribute('padding','0')
+    hashTable.setAttribute('columns','')
+    hashTable.setAttribute('format-key','true')
+    metastanzaDiv.appendChild(hashTable);
+  }
+</script>
+
 <togostanza-hash-table
   data-url="https://integbio.jp/togosite/sparqlist/api/disease_hpo_details?hp={{id}}"
   data-type="json"

--- a/config/togosite-human/templates/disease.hbs
+++ b/config/togosite-human/templates/disease.hbs
@@ -1,74 +1,100 @@
 <div id="metastanza">
+  <h1>Disease: {{type}}: {{id}}</h1>
+</div>
 <script>
+  // togoid endpoint
+  const togoidAPIURL = 'https://api.togoid.dbcls.jp.il3c.com';
+  const idTypes = ['mondo', 'nando', 'hp', 'mesh'];
+
+  // embed the id and id type via handlebars variable
+  const subjectId = "{{id}}";
+  const subjectIdType = "{{type}}";
+
+  // for testing
+  // const subjectId = "0011514";
+  // const subjectIdType = 'mondo';
+
+  // access API and return JSON
+  const fetchJSON = async (api) => {
+    const response = await fetch(api);
+    const json = await response.json();
+    return json;
+  }
+
+  // helper function to set multiple attributes
+  const updateAttributes = (element, attributes) => {
+    for (let key in attributes) {
+      element.setAttribute(key, attributes[key]);
+    }
+  }
+
+  // create a list of target ID types by removing the subject ID type
+  const targetIdTypes = async (subjectIdType) => {
+    const index = idTypes.indexOf(subjectIdType);
+    if (index > -1) {
+      idTypes.splice(index, 1);
+    }
+    return idTypes;
+  }
+
+  // access convert APi endpoint and create ID Object
+  const convertId = async (subjectId, subjectIdType) => {
+    const targets = await targetIdTypes(subjectIdType);
+    const array = [];
+    for (const targetIdType of targets) {
+      const url = togoidAPIURL + '/convert?ids=' + subjectId + '&route=' + subjectIdType + ',' + targetIdType;
+      const json = await fetchJSON(url);
+      if (json.results.length != 0) {
+        array.push({
+          'type': targetIdType,
+          'ids': json.results
+        });
+      }
+    }
+    return array;
+  }
+
   const metastanzaDiv = document.getElementById("metastanza");
+  const dataUrl = (id, type) => 'https://integbio.jp/togosite/sparqlist/api/test_disease_template_2?id=' + id + '&type=' + type;
 
-  const response = await fetch("https://integbio.jp/togosite/sparqlist/api/disease_id_converter?id={{id}}");
-  const idObjs = await response.json();
+  const addHeader = (id, type) => {
+    const header = document.createElement('h2');
+    const headerText = document.createTextNode(type + ': ' + id);
+    header.appendChild(headerText);
+    metastanzaDiv.appendChild(header);
+  }
 
-  for (const idObj of idObjs) {
+  const addHashTable = (id, type) => {
     const hashTable = document.createElement('togostanza-hash-table');
-    hashTable.setAttribute('data-url','https://integbio.jp/togosite/sparqlist/api/disease_hpo_details?id=' + idObj.id + '&type=' idObj.type)
-    hashTable.setAttribute('data-type','json')
-    hashTable.setAttribute('width','800')
-    hashTable.setAttribute('height','400')
-    hashTable.setAttribute('padding','0')
-    hashTable.setAttribute('columns','')
-    hashTable.setAttribute('format-key','true')
+    updateAttributes(hashTable, {
+      'data-url': dataUrl(id, type),
+      'data-type': 'json',
+      'format-key': true,
+      columns: ''
+    })
     metastanzaDiv.appendChild(hashTable);
   }
+
+  const addMainSubject = () => {
+    addHeader(subjectId, subjectIdType);
+    addHashTable(subjectId, subjectIdType);
+  }
+
+  const createMetastanza = async () => {
+    addMainSubject();
+    const array = await convertId(subjectId, subjectIdType);
+    for (const idObj of array) {
+      for (const id of idObj.ids) {
+        const type = idObj.type;
+        const data = await fetchJSON(dataUrl(id, type));
+        if (data.length > 0) {
+          addHeader(id, type);
+          addHashTable(id, type);
+        }
+      }
+    }
+  }
+
+  // exec
+  createMetastanza();
 </script>
-
-<togostanza-hash-table
-  data-url="https://integbio.jp/togosite/sparqlist/api/disease_hpo_details?hp={{id}}"
-  data-type="json"
-  width="800"
-  height="400"
-  padding="0"
-  columns=""
-  format-key="true"
-></togostanza-hash-table>
-
-<h2>MeSH Descriptor {{id}}</h2>
-<togostanza-hash-table
-  data-url="https://integbio.jp/togosite/sparqlist/api/mesh_descriptor?queryId={{id}}"
-  data-type="json"
-  width="800"
-  height="400"
-  padding="0"
-  columns="[{&quot;id&quot;: &quot;id&quot;, &quot;label&quot;: &quot;MeSH UID&quot;},
-            {&quot;id&quot;: &quot;label&quot;}, {&quot;id&quot;: &quot;scope_note&quot;},
-            {&quot;id&quot;: &quot;tree_numbers&quot;}]"
-  format-key="true"
-></togostanza-hash-table>
-
-<h2> mondo {{id}} summary</h2>
-
-togostanza-hash-table {
-    --key-font-size: 16px;
-  }
-
-<togostanza-hash-table
-  data-url="https://integbio.jp/togosite/sparqlist/api/disease-mondo?mondo={{id}}"
-  data-type="json"
-  width="800"
-  height="400"
-  padding="0"
-  columns="[{&quot;id&quot;: &quot;ID&quot;,&quot;label&quot;:&quot;Mondo ID&quot;}, {&quot;id&quot;: &quot;label&quot;,&quot;label&quot;:&quot;Disease name&quot;},{&quot;id&quot;: &quot;synonym_label&quot;,&quot;label&quot;:&quot;Synonym(s)&quot;},{&quot;id&quot;: &quot;difinition&quot;,&quot;label&quot;:&quot;Disease difinition&quot;},{&quot;id&quot;: &quot;related_databases&quot;,&quot;label&quot;:&quot;Other related database ID(s)&quot;},{&quot;id&quot;: &quot;Upper_classID&quot;,&quot;label&quot;:&quot;Mondo upper disease ID&quot;},{&quot;id&quot;: &quot;Upper_class_label&quot;,&quot;label&quot;:&quot;Mondo upper class disase&quot;}]"
-  format-key="true"
-></togostanza-hash-table>
-
-<h2> nando {{id}} summary</h2>
-
-  togostanza-hash-table {
-    --key-font-size: 16px;
-  }
-
-<togostanza-hash-table
-  data-url="https://integbio.jp/togosite/sparqlist/api/Disease-nando?nando={{id}}"
-  data-type="json"
-  width="800"
-  height="400"
-  padding="0"
-  columns="[{&quot;id&quot;: &quot;ID&quot;,&quot;label&quot;:&quot;NANDO ID&quot;}, {&quot;id&quot;: &quot;label_e&quot;,&quot;label&quot;:&quot;Disease name(E)&quot;}, {&quot;id&quot;: &quot;label_j&quot;,&quot;label&quot;:&quot;Disease name(J)&quot;}, {&quot;id&quot;: &quot;synonym_label&quot;,&quot;label&quot;:&quot;Synonym(s)&quot;}, {&quot;id&quot;: &quot;description&quot;,&quot;label&quot;:&quot;Disease description&quot;}, {&quot;id&quot;: &quot;mondo&quot;,&quot;label&quot;:&quot;Related Mondo ID&quot;,&quot;link&quot;:&quot;mondo&quot;}, {&quot;id&quot;: &quot;source&quot;,&quot;label&quot;:&quot;Source document&quot;,&quot;link&quot;:&quot;source&quot;}, {&quot;id&quot;: &quot;upper&quot;,&quot;label&quot;:&quot;NANDO upper disease ID&quot;}, {&quot;id&quot;: &quot;upper_label&quot;,&quot;label&quot;:&quot;NANDO upper class disase&quot;}]"
-  format-key="true"
-></togostanza-hash-table>

--- a/config/togosite-human/templates/disease.hbs
+++ b/config/togosite-human/templates/disease.hbs
@@ -43,7 +43,7 @@
     const targets = await targetIdTypes(subjectIdType);
     const array = [];
     for (const targetIdType of targets) {
-      const url = togoidAPIURL + '/convert?ids=' + subjectId + '&route=' + subjectIdType + ',' + targetIdType;
+      const url = togoidAPIURL + '/convert?format=json&ids=' + subjectId + '&route=' + subjectIdType + ',' + targetIdType;
       const json = await fetchJSON(url);
       if (json.results.length != 0) {
         array.push({

--- a/config/togosite-human/templates/disease.hbs
+++ b/config/togosite-human/templates/disease.hbs
@@ -4,6 +4,7 @@
 <script>
   // togoid endpoint
   const togoidAPIURL = 'https://api.togoid.dbcls.jp.il3c.com';
+  const dataUrlEndpoint = 'https://integbio.jp/togosite/sparqlist/api/test_disease_template_2';
   const idTypes = ['mondo', 'nando', 'hp', 'mesh'];
 
   // embed the id and id type via handlebars variable
@@ -55,7 +56,7 @@
   }
 
   const metastanzaDiv = document.getElementById("metastanza");
-  const dataUrl = (id, type) => 'https://integbio.jp/togosite/sparqlist/api/test_disease_template_2?id=' + id + '&type=' + type;
+  const dataUrl = (id, type) => dataUrlEndpoint + '?id=' + id + '&type=' + type;
 
   const addHeader = (id, type) => {
     const header = document.createElement('h2');
@@ -71,7 +72,7 @@
       'data-type': 'json',
       'format-key': true,
       columns: ''
-    })
+    });
     metastanzaDiv.appendChild(hashTable);
   }
 

--- a/config/togosite-human/templates/disease.hbs
+++ b/config/togosite-human/templates/disease.hbs
@@ -65,13 +65,26 @@
     metastanzaDiv.appendChild(header);
   }
 
-  const addHashTable = (id, type) => {
+  const generateColumnSetting = async (id, type) => {
+    const data = await fetchJSON(dataUrl(id, type));
+    return Object.entries(data[0]).map(([key, value]) => {
+      const obj = {};
+      obj.id = key;
+      if (/^http(s|)\:\/\//.test(value)) {
+        obj.link = key;
+      }
+      return obj;
+    });
+  }
+
+  const addHashTable = async (id, type) => {
     const hashTable = document.createElement('togostanza-hash-table');
+    const columnSetting = await generateColumnSetting(id, type);
     updateAttributes(hashTable, {
       'data-url': dataUrl(id, type),
       'data-type': 'json',
       'format-key': true,
-      columns: ''
+      columns: JSON.stringify(columnSetting)
     });
     metastanzaDiv.appendChild(hashTable);
   }


### PR DESCRIPTION
やってること:
- `id`, `type` をフロントエンドから受け取る
- togoid API を使って同一Subjectの別IDに変換する
- 入力されたIDおよび変換された各IDごとに hash-table を生成する
   - hash-table 用の data を生成しているSPARQListはこれ https://integbio.jp/togosite/sparqlist/test_disease_template_2

template を作る目的は subject ごとに表示したい UI のロジックをフロントエンドから分離すること、だとすればこれでいいのではなかろうか。jsもうちょっと綺麗に書ける気がするけど。