### PR TITLE
changed ensembl-transcript-category into ensembl-gene-biotype

### DIFF
--- a/config/togosite-human/properties.json
+++ b/config/togosite-human/properties.json
@@ -34,11 +34,11 @@
         "viewMethod": "histogram"
       },
       {
-        "propertyId": "ensembl-transcript-category",
-        "label": "Transcript-category",
-        "description": "transcript category",
-        "data": "https://integbio.jp/togosite/sparqlist/api/Ensembl_transcript_description",
-        "primaryKey": "ensembl_transcript"
+        "propertyId": "ensembl-gene-biotype",
+        "label": "Gene biotype",
+        "description": "Biotypes of genes annotated in Ensembl",
+        "data": "https://integbio.jp/togosite/sparqlist/api/Ensembl_gene_type",
+        "primaryKey": "ensembl_gene"
       },
       {
         "propertyId": "homologene_human_paralog_count",


### PR DESCRIPTION
従来 https://integbio.jp/togosite/sparqlist/Ensembl_transcript_description を用いて表示していた `Transcript category` のバーですが、
Transcript 単位に対して付けられた他のバーがほぼ存在しないことから、
遺伝子単位に対して付けられた type のほうが有用であると考え、変更しました。
https://integbio.jp/togosite/sparqlist/Ensembl_gene_type

これにより、例えば GTEx v6 で testis specific とされている遺伝子 13026 個のタイプの内訳を togosite 上で確認できるようになります。元論文によると以下のようになっています。
```
3923 protein coding genes
5804 lncRNAs
3299 pseudogenes
...
```
従来 `Category` としていた呼称は、[Ensembl での呼称](http://useast.ensembl.org/info/genome/genebuild/biotypes.html)に従い、`biotype` としました。

cc @hchiba1 @takaitakai7 