### PR TITLE
ChEBI関係のBarを追加しました

### DIFF
--- a/config/togosite-human/properties.json
+++ b/config/togosite-human/properties.json
@@ -312,6 +312,30 @@
     "togoKeyExamples": ["564", "1046", "1981"],
     "properties": [
       {
+        "propertyId": "chembl_substance_type",
+        "label": "Substance type",
+        "description": "Substance types in ChEMBL",
+        "data": "https://integbio.jp/togosite/sparqlist/api/chembl_substancetype",
+        "primaryKey": "chembl_compound",
+        "keyLabel": "ChEMBL compound"
+      },
+      {
+        "propertyId": "chebi_chemical_role",
+        "label": "Chemical role",
+        "description": "Chemical roles in ChEBI",
+        "data": "http://integbio.jp/togosite/sparqlist/compound_biological_role_chebi",
+        "primaryKey": "chebi_compound",
+        "keyLabel": "ChEBI compound"
+      },
+      {
+        "propertyId": "chebi_application_type",
+        "label": "Application type",
+        "description": "Application types in ChEBI",
+        "data": "http://integbio.jp/togosite/sparqlist/compound_application_chebi",
+        "primaryKey": "chebi_compound",
+        "keyLabel": "ChEBI compound"
+      },
+      {
         "propertyId": "chembl_mechanism_action_type",
         "label": "Action type",
         "description": "Mechanism action types in ChEMBL",
@@ -320,12 +344,12 @@
         "keyLabel": "ChEMBL compound"
       },
       {
-        "propertyId": "chembl_substance_type",
-        "label": "Substance type",
-        "description": "Substance types in ChEMBL",
-        "data": "https://integbio.jp/togosite/sparqlist/api/chembl_substancetype",
-        "primaryKey": "chembl_compound",
-        "keyLabel": "ChEMBL compound"
+        "propertyId": "chebi_biological_role",
+        "label": "Biological role",
+        "description": "Biological roles in ChEBI",
+        "data": "http://integbio.jp/togosite/sparqlist/compound_biological_role_chebi",
+        "primaryKey": "chebi_compound",
+        "keyLabel": "ChEBI compound"
       },
       {
         "propertyId": "chembl_mesh",

--- a/config/togosite-human/properties.json
+++ b/config/togosite-human/properties.json
@@ -323,7 +323,7 @@
         "propertyId": "chebi_chemical_role",
         "label": "Chemical role",
         "description": "Chemical roles in ChEBI",
-        "data": "http://integbio.jp/togosite/sparqlist/compound_biological_role_chebi",
+        "data": "http://integbio.jp/togosite/sparqlist/compound_chemical_role_chebi",
         "primaryKey": "chebi_compound",
         "keyLabel": "ChEBI compound"
       },
@@ -376,7 +376,7 @@
         "keyLabel": "PubChem compound"
       },
       {
-        "propertyId": "atc_classification_pubchem_chembl",
+        "propertyId": "atc_classification_chembl",
         "label": "ChEMBL ATC classification",
         "description": "Anatomical Therapeutic Chemical (ATC) Classification in ChEMBL",
         "data": "https://integbio.jp/togosite/sparqlist/api/atcClassificationChEMBL",

--- a/config/togosite-human/properties.json
+++ b/config/togosite-human/properties.json
@@ -331,7 +331,7 @@
         "propertyId": "chebi_application_type",
         "label": "Application type",
         "description": "Application types in ChEBI",
-        "data": "http://integbio.jp/togosite/sparqlist/compound_application_chebi",
+        "data": "http://integbio.jp/togosite/sparqlist/compound_application_type_chebi",
         "primaryKey": "chebi_compound",
         "keyLabel": "ChEBI compound"
       },

--- a/config/togosite-human/properties.json
+++ b/config/togosite-human/properties.json
@@ -323,7 +323,7 @@
         "propertyId": "chebi_chemical_role",
         "label": "Chemical role",
         "description": "Chemical roles in ChEBI",
-        "data": "http://integbio.jp/togosite/sparqlist/compound_chemical_role_chebi",
+        "data": "http://integbio.jp/togosite/sparqlist/api/compound_chemical_role_chebi",
         "primaryKey": "chebi_compound",
         "keyLabel": "ChEBI compound"
       },
@@ -331,7 +331,7 @@
         "propertyId": "chebi_application_type",
         "label": "Application type",
         "description": "Application types in ChEBI",
-        "data": "http://integbio.jp/togosite/sparqlist/compound_application_type_chebi",
+        "data": "http://integbio.jp/togosite/sparqlist/api/compound_application_type_chebi",
         "primaryKey": "chebi_compound",
         "keyLabel": "ChEBI compound"
       },
@@ -347,7 +347,7 @@
         "propertyId": "chebi_biological_role",
         "label": "Biological role",
         "description": "Biological roles in ChEBI",
-        "data": "http://integbio.jp/togosite/sparqlist/compound_biological_role_chebi",
+        "data": "http://integbio.jp/togosite/sparqlist/api/compound_biological_role_chebi",
         "primaryKey": "chebi_compound",
         "keyLabel": "ChEBI compound"
       },


### PR DESCRIPTION
6/21の定例会議で信定さんから報告のあった

- ChEBIについて情報を整理しChEBIを使った以下のsparqlist作成
    -  application:　https://integbio.jp/togosite/sparqlist/test_compound_application_chebi
         - pharmaceutical(製薬),pesticide(農薬) 等
    - biological role:　https://integbio.jp/togosite/sparqlist/test_compound_biological_role_chebi
         - inhibitor(阻害剤),antimicrobial agent(抗菌薬)　等
    - chemical role:　https://integbio.jp/togosite/sparqlist/test_compound_chemical_role_chebi
         - antioxidant(抗酸化剤),environmental contaminant(環境汚染物質)　等 

について、properties.jsonに追加しました。
その際、Barの順番を
-  Substance type
-  Chemical Role (*)
-  Application Type (*)
- Action Type
- Biological Role (*)
- Drug indication
- Drug development phase
- ATC Classification ( 2種類）
 
(* 新規）
に並べ替えました。
上の３つは生物関係なく化合物としての分類、次の2つは生物とか、生体物質とかについてのかかわりに関する分類、残りは薬としての分類、のつもりです。

また、 ChEMBL ATC Classification のところ
“propertyId”: “atc_classification_pubchem_chembl”
となっていたのを修正しました。propertyIdを変えることで他にも変更が必要な個所がありましたらご指示ください。