### PR TITLE
Replace variant consequence with variant gwas

### DIFF
--- a/config/togosite-human/properties.json
+++ b/config/togosite-human/properties.json
@@ -651,10 +651,10 @@
     "subjectId": "variant",
     "properties": [
       {
-        "propertyId": "variant_consequence_togovar",
-        "label": "Consequence",
-        "description": "Classification of variants based on the consequence from TogoVar, such as amino acid substitution or frameshift. Predicted by the Variant Effect Predictor (VEP)",
-        "data": "https://integbio.jp/togosite/sparqlist/api/variant_consequence_togovar",
+        "propertyId": "variant_gwas_togovar",
+        "label": "GWAS",
+        "description": "Classification of statistically significant variants in genome-wide association studies (GWAS) based on associated traits. Obtained from GWAS catalog via TogoVar.",
+        "data": "https://integbio.jp/togosite/sparqlist/api/variant_gwas_togovar",
         "dataSource": "",
         "dataSourceUrl": "",
         "dataSourceVersion": "",

--- a/config/togosite-human/properties.json
+++ b/config/togosite-human/properties.json
@@ -653,7 +653,7 @@
       {
         "propertyId": "variant_gwas_togovar",
         "label": "GWAS",
-        "description": "Classification of statistically significant variants in genome-wide association studies (GWAS) based on associated traits. Obtained from GWAS catalog via TogoVar.",
+        "description": "Classification of statistically significant variants in genome-wide association studies (GWAS) based on associated traits. Obtained from GWAS catalog via TogoVar",
         "data": "https://integbio.jp/togosite/sparqlist/api/variant_gwas_togovar",
         "dataSource": "",
         "dataSourceUrl": "",


### PR DESCRIPTION
variantのconsequenceのバーをGWASに差し替えさせてください。

ここに書くことでないかもしれませんが、PRする前にfrontendで確認できるとありがたいと思いました。ただ、新規バーを追加は少ないので優先順位は低いです。以下の２つの方法を考えてみましたが、簡単ではないようにも思いました。
1.  [sparqlist-developのproperties.json](https://github.com/dbcls/togosite/blob/sparqlist-develop/config/togosite-human/properties.json)を開発者が編集できる。→ github actionで同期しているので勝手に変更出来なさそう。
2. git clone https://github.com/dbcls/togosite して自分のmacで立ち上げる。→ 以下のコードをnodeに渡して画面は表示できたが、properties.jsonの変更が反映されないので、buildする必要あり？Slackの以下の話に期待でしょうか。
> 残タスクとしては、永野さんのお手元でjsをビルドしてからpushしてもらっている現状のフローを変更して source だけ上げてもらって、github actions で gulp.js だか Grunt.js だかを使ってビルドするというのがありますが積み中。

```
'use strict';
const express = require('express');
const app = express();
app.use(express.static('./frontend/build'));
app.listen(8001, ()=> {
  console.log('Express Server for Togosite frontend at http://localhost:8001');
});
```