### PR TITLE
attributes config

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -1,3 +1,123 @@
+# Togoサイトのフロントが期待するAPIの整理
+
+## 各SPARQList（AttributeのAPI）の仕様
+
+* トップページのバーを表示するために必要なもの
+  * カテゴリIDの指定がないとき → トップレベルのオブジェクトリストを返す（→ APIサーバがカウントして返す）
+    * 正確にはproperty pathsで下位階層の全オブジェクトがここで返ってきている！！
+  * カテゴリIDの指定があるとき → 下位階層のオブジェクトリストを返す（→同上）
+    * ※カテゴリIDは１つしか受け取らない
+* Add filter
+  * （APIサーバが処理してくれるはず）
+* Map attributes
+  * （APIサーバが処理してくれるはず）
+
+⇒ categoryIds → category, queryIds → 廃止, mode → 廃止
+
+## キャッシュサーバの仕様
+
+### 内訳を取得 (category ID を 0 か 1 つ受け取る)
+
+https://togodx.dbcls.jp/api/get_counts?attribute=gene_biotype_ensembl(&category=ID)
+→ attributes.jsonを見てhttps://integbio.jp/togosite/sparqlist/api/gene_biotype_ensemblなどを呼び出す
+
+* キャッシュがあるか確認する
+* 各APIを呼び出してオブジェクトリストを受け取ってキャッシュする（下位階層の全オブジェクトが返ってきている）
+* オブジェクトリストのカウントを集計してフロントに返す
+
+```
+  {
+    "id": "ENSG00000181092",
+    "attribute": {
+      "categoryId": "UBERON_0001013",
+      "uri": "http://purl.obolibrary.org/obo/UBERON_0001013",
+      "label": "Adipose tissue"
+    }
+  },
+```
+
+⇒ この時点で
+* トップ階層で全データの入った attribute, id, category, uri, label の表を作れる（カテゴリのuri, labelは別表にするかどうか）
+* サブカテゴリについても同じ構造で、categoryカラムのIDで絞り込みができる
+
+### Map your IDs (queryIdsを1つ以上受け取る)
+
+現状フロントからは `data_from_user_ids` のSPARQLetを呼んでいる
+
+1. 全てのバー（トップ階層）にマップする
+
+各attributeに対して下記の呼び出しを行う（property pathsで下位階層へのマップ数も全て拾っている）
+
+https://togodx.dbcls.jp/api/get_counts?attribute=gene_biotype_ensembl&queries=ID1,ID2
+→ 特に外部APIは呼び出さずキャッシュサーバ内で解決できる
+
+⇒ 上記のトップ階層の表からquery IDでgrepするだけでOKそう（トップ階層のcategory IDがどれかというのは知っておく必要がある）
+
+2. マップされたIDがサブ階層のどこに該当しているかを調べる
+
+クリックされたカテゴリIDと、マップするIDを渡す
+
+https://togodx.dbcls.jp/api/get_counts?attribute=gene_biotype_ensembl&queries=ID1,ID2&cateogory=ID
+→ 該当カテゴリIDのキャッシュがあれば利用、無ければ呼び出し
+
+⇒ サブ階層の表からquery IDでgrepするだけ
+
+3. マップ数やp-valueを計算して返す
+
+* 変換済みのIDを受け取って map_ids_to_attribute SPARQLetがやっていることを再現（query IDの入っているオブジェクトを検索して、そのオブジェクトのカテゴリも取得し、カテゴリのカウントおよび総数を取得、p-valueを計算）
+  * カテゴリID
+  * ラベル
+  * カウント数(カテゴリ内の総数)
+  * ヒット数
+  *  p-value (トータル数を使ってp-valueを計算する)
+    * 各APIが総数を返さないケースへの対応 (w/o アノテーションのID数が不明)
+
+⇒ 課題として、p-valueの計算速度を向上したい & トータル数を返すAPIもしくはJSONをどこに置くか
+
+### View results でテーブルを生成
+
+* 各 attribute 毎に下記を取得、集計して表を作る
+  * キャッシュからqueryIdに対応するオブジェクトのリストを返す
+
+1. Add filter
+
+* カテゴリの場合（booleanも含む）
+  * attributeと選択されたcategory IDsが渡される
+* 連続値の場合
+  * attributeと値の範囲が渡される
+* primary key (Select target) も知っておく必要がある
+
+⇒ 表から
+* keyが一致する場合、表から該当するIDのセットをattributeごとに取得できる
+* keyが一致しない場合、primary keyからIDを変換して、表から該当するIDのセットを取得する
+
+2. Map attributes
+
+* カテゴリの場合
+  * 選ばれた階層でカテゴリを表にする、棒グラフはカテゴリごとに内訳を集計する
+* 連続値の場合
+  * 実際の値を表にする、棒グラフはビンに整理する？
+
+⇒ Add filterで絞り込まれたkeyが各カテゴリのトータル中に何個該当するかを計算する必要がある
+
+
+### キャッシュをクリア
+
+* attributeを指定してクリアするオプション
+
+## TODO
+
+* キャッシュサーバの要求仕様はだいぶ見えてきた
+* これをうけてattributes.jsonとAPIのパラメータ＆返すJSONの仕様を最終確認する
+* まあでもキャッシュサーバのプロトタイピングをしながらリファインしていくのがいいかな
+
+## その他
+
+* Select target で選んだ key から conversion で変換できない attribute はグレーアウトしたい
+
+
+---
+
 # TogoSite configuration JSON
 
 ## Data Structure

--- a/config/togosite-human/attributes.json
+++ b/config/togosite-human/attributes.json
@@ -1,660 +1,662 @@
 {
-  "categories": [
+  "tracks": [
     {
       "id": "gene",
       "label": "Gene",
       "attributes": [
-        {
-          "id": "gene_biotype_ensembl",
-          "label": "Gene biotype",
-          "description": "Gene or transcript classification annotated in Ensembl",
-          "data": "https://integbio.jp/togosite/sparqlist/api/gene_biotype_ensembl",
-          "idType": "ensembl_gene",
-          "dataSource": {
-            "label": "Ensembl",
-            "url": "http://nov2020.archive.ensembl.org/Homo_sapiens/Info/Index",
-            "updateDate": "14 Jul, 2021"
-          }
-        },
-        {
-          "id": "gene_chromosome_ensembl",
-          "label": "Chromosome",
-          "description": "Chromosome where a gene is located",
-          "data": "https://integbio.jp/togosite/sparqlist/api/gene_chromosome_ensembl",
-          "idType": "ensembl_gene",
-          "dataSource": {
-            "label": "Ensembl human release 102",
-            "url": "http://nov2020.archive.ensembl.org/Homo_sapiens/Info/Index",
-            "updateDate": "14 Jul, 2021"
-          }
-        },
-        {
-          "id": "gene_number_of_exons_ensembl",
-          "label": "# of exons",
-          "description": "Number of exons for each transcript of each gene",
-          "data": "https://integbio.jp/togosite/sparqlist/api/gene_number_of_exons_ensembl",
-          "idType": "ensembl_transcript",
-          "dataSource": {
-            "label": "Ensembl human release 102",
-            "url": "http://nov2020.archive.ensembl.org/Homo_sapiens/Info/Index",
-            "updateDate": "14 Jul, 2021"
-          }
-        },
-        {
-          "id": "gene_number_of_paralogs_homologene",
-          "label": "# of paralogs",
-          "description": "Number of duplicated genes (paralogs) in each human gene calculated based on HomoloGene",
-          "data": "https://integbio.jp/togosite/sparqlist/api/gene_number_of_paralogs_homologene",
-          "idType": "ncbigene",
-          "dataSource": {
-            "label": "HomoloGene",
-            "url": "https://www.ncbi.nlm.nih.gov/homologene/statistics/",
-            "updateDate": "14 Jul, 2021"
-          }
-        },
-        {
-          "id": "gene_evolutionary_conservation_homologene",
-          "label": "Evolutionary divergence",
-          "description": "Most distant organisms from human that have orthologous genes in HomoloGene",
-          "data": "https://integbio.jp/togosite/sparqlist/api/gene_evolutionary_conservation_homologene",
-          "idType": "ncbigene",
-          "dataSource": {
-            "label": "HomoloGene",
-            "url": "https://www.ncbi.nlm.nih.gov/homologene/statistics/",
-            "updateDate": "14 Jul, 2021"
-          }
-        },
-        {
-          "id": "gene_high_level_expression_refex",
-          "label": "High-level expression",
-          "description": "Tissues in which a gene was tissue-specific highly expressed only in one of 34 tissues of RefEx",
-          "data": "https://integbio.jp/togosite/sparqlist/api/gene_high_level_expression_refex",
-          "idType": "ncbigene",
-          "dataSource": {
-            "label": "Calculations for tissue specificity of genechip human GSE7307 from RefEx",
-            "url": "https://doi.org/10.6084/m9.figshare.4028700.v3",
-            "updateDate": "14 Jul, 2021"
-          }
-        },
-        {
-          "id": "gene_low_level_expression_refex",
-          "label": "Low-level expression",
-          "description": "Tissues in which a gene was tissue-specific lowly expressed only in one of 34 tissues of RefEx",
-          "data": "https://integbio.jp/togosite/sparqlist/api/gene_low_level_expression_refex",
-          "idType": "ncbigene",
-          "dataSource": {
-            "label": "Calculations for tissue specificity of genechip human GSE7307 from RefEx",
-            "url": "https://doi.org/10.6084/m9.figshare.4028700.v3",
-            "updateDate": "14 Jul, 2021"
-          }
-        },
-        {
-          "id": "gene_high_level_expression_gtex6",
-          "label": "Expressed in tissues",
-          "description": "Tissues in which a gene is tissue-specific highly expressed in 48 tissues of GTEx",
-          "data": "https://integbio.jp/togosite/sparqlist/api/gene_high_level_expression_gtex6",
-          "idType": "ensembl_gene",
-          "dataSource": {
-            "label": "Supplementary Table 1 of A systematic survey of human tissue-specific gene expression and splicing reveals new opportunities for therapeutic target identification and evaluation; R. Y. Yang et al.; bioRxiv 311563",
-            "url": "https://doi.org/10.1101/311563",
-            "updateDate": "14 Jul, 2021"
-          }
-        },
-        {
-          "id": "gene_not_expressed_in_tissue_gtex",
-          "label": "Not expressed in tissues",
-          "description": "Tissues in which expression of a gene is not detected in 48 tissues of GTEx",
-          "data": "https://integbio.jp/togosite/sparqlist/api/gene_not_expressed_in_tissues_gtex",
-          "idType": "ensembl_gene",
-          "dataSource": {
-            "label": "Supplementary Table 1 of A systematic survey of human tissue-specific gene expression and splicing reveals new opportunities for therapeutic target identification and evaluation; R. Y. Yang et al.; bioRxiv 311563",
-            "url": "https://doi.org/10.1101/311563",
-            "updateDate": "14 Jul, 2021"
-          }
-        },
-        {
-          "id": "gene_transcription_factors_chip_atlas",
-          "label": "Transcription factors",
-          "description": "Transcription factors with predicted target genes in ChIP-Atlas",
-          "data": "https://integbio.jp/togosite/sparqlist/api/gene_transcription_factors_chip_atlas",
-          "idType": "ensembl_gene",
-          "dataSource": {
-            "label": "ChIP-Atlas",
-            "url": "http://dbarchive.biosciencedbc.jp/kyushu-u/hg38/target/",
-            "updateDate": "14 Jul, 2021"
-          }
-        }
+        "gene_biotype_ensembl",
+        "gene_chromosome_ensembl",
+        "gene_number_of_exons_ensembl",
+        "gene_number_of_paralogs_homologene",
+        "gene_evolutionary_conservation_homologene",
+        "gene_high_level_expression_refex",
+        "gene_low_level_expression_refex",
+        "gene_high_level_expression_gtex6",
+        "gene_not_expressed_in_tissue_gtex",
+        "gene_transcription_factors_chip_atlas"
       ]
     },
     {
       "id": "protein",
       "label": "Protein",
       "attributes": [
-        {
-          "id": "protein_domains_uniprot",
-          "label": "Protein domains",
-          "description": "Protein domains from UniProt",
-          "data": "https://integbio.jp/togosite/sparqlist/api/protein_domains_uniprot",
-          "idType": "uniprot",
-          "dataSource": {
-            "label": "",
-            "url": "",
-            "updateDate": ""
-          }
-        },
-        {
-          "id": "protein_cellular_component_uniprot",
-          "label": "Cellular component",
-          "description": "Functional annotations (GO terms) derived from the Cellular component category of GeneOntology, which Uniprot has assigned to each human protein with evidence information",
-          "data": "https://integbio.jp/togosite/sparqlist/api/protein_cellular_component_uniprot",
-          "idType": "uniprot",
-          "dataSource": {
-            "label": "",
-            "url": "",
-            "updateDate": ""
-          }
-        },
-        {
-          "id": "protein_biological_process_uniprot",
-          "label": "Biological process",
-          "description": "Functional annotations (GO terms) derived from the Biological process category of GeneOntology, which Uniprot has assigned to each human protein with evidence information",
-          "data": "https://integbio.jp/togosite/sparqlist/api/protein_biological_process_uniprot",
-          "idType": "uniprot",
-          "dataSource": {
-            "label": "",
-            "url": "",
-            "updateDate": ""
-          }
-        },
-        {
-          "id": "protein_molecular_function_uniprot",
-          "label": "Molecular function",
-          "description": "Functional annotations (GO terms) derived from the Molecular function category of GeneOntology, which Uniprot has assigned to each human protein with evidence information",
-          "data": "https://integbio.jp/togosite/sparqlist/api/protein_molecular_function_uniprot",
-          "idType": "uniprot",
-          "dataSource": {
-            "label": "",
-            "url": "",
-            "updateDate": ""
-          }
-        },
-        {
-          "id": "protein_ligands_uniprot",
-          "label": "Ligands",
-          "description": "Classification by non-protein molecules which bind/react with proteins in Function section from UniProt",
-          "data": "https://integbio.jp/togosite/sparqlist/api/protein_ligands_uniprot",
-          "idType": "uniprot",
-          "dataSource": {
-            "label": "",
-            "url": "",
-            "updateDate": ""
-          }
-        },
-        {
-          "id": "protein_molecular_mass_uniprot",
-          "label": "Molecular mass",
-          "description": "Molecular weight of the protein including information from multiple isoforms in Sequences section from UniProt",
-          "data": "https://integbio.jp/togosite/sparqlist/api/protein_molecular_mass_uniprot",
-          "idType": "uniprot",
-          "dataSource": {
-            "label": "",
-            "url": "",
-            "updateDate": ""
-          }
-        },
-        {
-          "id": "protein_ptms_uniprot",
-          "label": "PTMs",
-          "description": "Classification by types of post-translational modifications, including S-S bonds (disulfide bonds) in Amino acid modifications section from UniProt",
-          "data": "https://integbio.jp/togosite/sparqlist/api/protein_ptms_uniprot",
-          "idType": "uniprot",
-          "dataSource": {
-            "label": "",
-            "url": "",
-            "updateDate": ""
-          }
-        },
-        {
-          "id": "protein_number_of_transmembrane_domains_uniprot",
-          "label": "# of transmembrane domains",
-          "description": "Number of transmembrane domains. A group of molecules forming a family, such as channels, may have the same number of domains in Topology section from UniProt",
-          "data": "https://integbio.jp/togosite/sparqlist/api/protein_number_of_transmembrane_domains_uniprot",
-          "idType": "uniprot",
-          "dataSource": {
-            "label": "",
-            "url": "",
-            "updateDate": ""
-          }
-        },
-        {
-          "id": "protein_number_of_phosphorylation_sites_uniprot",
-          "label": "# of phosphorylation sites",
-          "description": "Number of phosphorylation at Ser/Thr/Tyr, which may create an activation state for the protein and acts like a switch in Amino acid modifications section from UniProt",
-          "data": "https://integbio.jp/togosite/sparqlist/api/protein_number_of_phosphorylation_sites_uniprot",
-          "idType": "uniprot",
-          "dataSource": {
-            "label": "",
-            "url": "",
-            "updateDate": ""
-          }
-        },
-        {
-          "id": "protein_number_of_glycosylation_sites_uniprot",
-          "label": "# of glycosylation sites",
-          "description": "Number of glycosylation sites, including N-linked,O-linked and others in Amino acid modifications section from UniProt",
-          "data": "https://integbio.jp/togosite/sparqlist/api/protein_number_of_glycosylation_sites_uniprot",
-          "idType": "uniprot",
-          "dataSource": {
-            "label": "",
-            "url": "",
-            "updateDate": ""
-          }
-        },
-        {
-          "id": "protein_disease_related_proteins_uniprot",
-          "label": "Disease-related proteins",
-          "description": "Disease-related proteins in Pathology & Biotech section from UniProt",
-          "data": "https://integbio.jp/togosite/sparqlist/api/protein_disease_related_proteins_uniprot",
-          "idType": "uniprot",
-          "dataSource": {
-            "label": "",
-            "url": "",
-            "updateDate": ""
-          }
-        },
-        {
-          "id": "protein_isolation_source_uniprot",
-          "label": "Tissues w/expression reported",
-          "description": "Classification based on the name of the tissue from which the clone was isolated in the reference describing the protein sequence in Tissue section from UniProt",
-          "data": "https://integbio.jp/togosite/sparqlist/api/protein_isolation_source_uniprot",
-          "idType": "uniprot",
-          "dataSource": {
-            "label": "",
-            "url": "",
-            "updateDate": ""
-          }
-        },
-        {
-          "id": "protein_evidence_of_existence_nextprot",
-          "label": "Evidence of existence",
-          "description": "Classification by the basis of protein expression, such as whether it has been identified as a protein or transcript in Expression section from neXtProt",
-          "data": "https://integbio.jp/togosite/sparqlist/api/protein_evidence_of_existence_nextprot",
-          "idType": "uniprot",
-          "dataSource": {
-            "label": "",
-            "url": "",
-            "updateDate": ""
-          }
-        }
+        "protein_domains_uniprot",
+        "protein_cellular_component_uniprot",
+        "protein_biological_process_uniprot",
+        "protein_molecular_function_uniprot",
+        "protein_ligands_uniprot",
+        "protein_molecular_mass_uniprot",
+        "protein_ptms_uniprot",
+        "protein_number_of_transmembrane_domains_uniprot",
+        "protein_number_of_phosphorylation_sites_uniprot",
+        "protein_number_of_glycosylation_sites_uniprot",
+        "protein_disease_related_proteins_uniprot",
+        "protein_isolation_source_uniprot",
+        "protein_evidence_of_existence_nextprot"
       ]
     },
     {
       "id": "proteinStructure",
       "label": "Protein structure",
       "attributes": [
-        {
-          "id": "structure_data_existence_uniprot",
-          "label": "Structure data existence",
-          "description": "Uniprot entries having 3D structure data in PDB in Structure section from Uniprot",
-          "data": "https://integbio.jp/togosite/sparqlist/api/structure_data_existence_uniprot",
-          "idType": "uniprot",
-          "dataSource": {
-            "label": "",
-            "url": "",
-            "updateDate": ""
-          }
-        },
-        {
-          "id": "structure_number_of_alpha_helices_pdb",
-          "label": "# of alpha-helices",
-          "description": "Number of 'Helix' entities counted in each entry of PDB",
-          "data": "https://integbio.jp/togosite/sparqlist/api/structure_number_of_alpha_helices_pdb",
-          "idType": "pdb",
-          "dataSource": {
-            "label": "",
-            "url": "",
-            "updateDate": ""
-          }
-        },
-        {
-          "id": "structure_number_of_beta_sheets_pdb",
-          "label": "# of beta-sheets",
-          "description": "Number of 'Sheet' entities counted in each entry of PDB",
-          "data": "https://integbio.jp/togosite/sparqlist/api/structure_number_of_beta_sheets_pdb",
-          "idType": "pdb",
-          "dataSource": {
-            "label": "",
-            "url": "",
-            "updateDate": ""
-          }
-        },
-        {
-          "id": "structure_number_of_peptides_pdb",
-          "label": "# of peptides in a PDB entry",
-          "description": "The number of peptides in a PDB entry",
-          "data": "https://integbio.jp/togosite/sparqlist/api/structure_number_of_peptides_pdb",
-          "idType": "pdb",
-          "dataSource": {
-            "label": "",
-            "url": "",
-            "updateDate": ""
-          }
-        },
-        {
-          "id": "structure_other_related_molecules_pdb",
-          "label": "Other related molecules",
-          "description": "Nonpeptide molecules related protein structures including water, metal ions, and low molecular weight compounds such as glycerol used to make crystals",
-          "data": "https://integbio.jp/togosite/sparqlist/api/structure_other_related_molecules_pdb",
-          "idType": "pdb",
-          "dataSource": {
-            "label": "",
-            "url": "",
-            "updateDate": ""
-          }
-        },
-        {
-          "id": "structure_analysis_methods_pdb",
-          "label": "Analysis methods",
-          "description": "Classification by the method used to determine the three-dimensional structure in Experimental method section from PDB",
-          "data": "https://integbio.jp/togosite/sparqlist/api/structure_analysis_methods_pdb",
-          "idType": "pdb",
-          "dataSource": {
-            "label": "",
-            "url": "",
-            "updateDate": ""
-          }
-        },
-        {
-          "id": "structure_crystallization_temperature_pdb",
-          "label": "Crystallization temperature",
-          "description": "Temperature of the crystallization solution obtained in Crystallization Conditions section from PDB",
-          "data": "https://integbio.jp/togosite/sparqlist/api/structure_crystallization_temperature_pdb",
-          "idType": "pdb",
-          "dataSource": {
-            "label": "",
-            "url": "",
-            "updateDate": ""
-          }
-        },
-        {
-          "id": "structure_crystallization_ph_pdb",
-          "label": "Crystallization pH",
-          "description": "pH value of the crystallization solution in Crystallization Conditions section from PDB",
-          "data": "https://integbio.jp/togosite/sparqlist/api/structure_crystallization_ph_pdb",
-          "idType": "pdb",
-          "dataSource": {
-            "label": "",
-            "url": "",
-            "updateDate": ""
-          }
-        }
+        "structure_data_existence_uniprot",
+        "structure_number_of_alpha_helices_pdb",
+        "structure_number_of_beta_sheets_pdb",
+        "structure_number_of_peptides_pdb",
+        "structure_other_related_molecules_pdb",
+        "structure_analysis_methods_pdb",
+        "structure_crystallization_temperature_pdb",
+        "structure_crystallization_ph_pdb"
       ]
     },
     {
       "id": "interaction",
       "label": "Interaction",
       "attributes": [
-        {
-          "id": "interaction_proteins_in_pathway_reactome",
-          "label": "Proteins in pathway",
-          "description": "Proteins participating as components classified by pathway (reaction) from Reactome",
-          "data": "https://integbio.jp/togosite/sparqlist/api/interaction_proteins_in_pathway_reactome",
-          "idType": "uniprot",
-          "dataSource": {
-            "label": "",
-            "url": "",
-            "updateDate": ""
-          }
-        },
-        {
-          "id": "interaction_compounds_in_pathway_reactome",
-          "label": "Compounds in pathway",
-          "description": "Compounds participating as components classified by pathway (reaction) from Reactome",
-          "data": "https://integbio.jp/togosite/sparqlist/api/interaction_compounds_in_pathway_reactome",
-          "idType": "chebi",
-          "dataSource": {
-            "label": "",
-            "url": "",
-            "updateDate": ""
-          }
-        },
-        {
-          "id": "interaction_number_of_interacting_proteins_uniprot",
-          "label": "# of interacting proteins",
-          "description": "Classification of uniprot proteins by the number of target proteins they interact with in Interaction section from UniProt",
-          "data": "https://integbio.jp/togosite/sparqlist/api/interaction_number_of_interacting_proteins_uniprot",
-          "idType": "uniprot",
-          "dataSource": {
-            "label": "",
-            "url": "",
-            "updateDate": ""
-          }
-        },
-        {
-          "id": "interaction_chembl_assay_existence_uniprot",
-          "label": "ChEMBL assay existence",
-          "description": "Uniprot entries classified according to the presence or absence of a method to detect direct protein-compound interactions (ChEMBL assay)",
-          "data": "https://integbio.jp/togosite/sparqlist/api/interaction_chembl_assay_existence_uniprot",
-          "idType": "uniprot",
-          "dataSource": {
-            "label": "",
-            "url": "",
-            "updateDate": ""
-          }
-        }
+        "interaction_proteins_in_pathway_reactome",
+        "interaction_compounds_in_pathway_reactome",
+        "interaction_number_of_interacting_proteins_uniprot",
+        "interaction_chembl_assay_existence_uniprot"
       ]
     },
     {
       "id": "chemicalCompound",
       "label": "Chemical compound",
       "attributes": [
-        {
-          "id": "compound_substance_type_chembl",
-          "label": "Substance type",
-          "description": "Classification based on the type of drug, such as compound or nucleic acid drugs from ChEMBL",
-          "data": "https://integbio.jp/togosite/sparqlist/api/compound_substance_type_chembl",
-          "idType": "chembl_compound",
-          "dataSource": {
-            "label": "",
-            "url": "",
-            "updateDate": ""
-          }
-        },
-        {
-          "id": "compound_chemical_role_chebi",
-          "label": "Chemical role",
-          "description": "Classification based on the chemical roles, such as antioxidant or environmental contaminant from ChEBI",
-          "data": "https://integbio.jp/togosite/sparqlist/api/compound_chemical_role_chebi",
-          "idType": "chebi",
-          "dataSource": {
-            "label": "",
-            "url": "",
-            "updateDate": ""
-          }
-        },
-        {
-          "id": "compound_application_type_chebi",
-          "label": "Application type",
-          "description": "Classification based on the application types, such as pharmaceutical or pesticide from ChEBI",
-          "data": "https://integbio.jp/togosite/sparqlist/api/compound_application_type_chebi",
-          "idType": "chebi",
-          "dataSource": {
-            "label": "",
-            "url": "",
-            "updateDate": ""
-          }
-        },
-        {
-          "id": "compound_action_type_chembl",
-          "label": "Action type",
-          "description": "Classification based on the mechanism of action, such as an inhibitor or an antagonist from ChEMBL",
-          "data": "https://integbio.jp/togosite/sparqlist/api/compound_action_type_chembl",
-          "idType": "chembl_compound",
-          "dataSource": {
-            "label": "",
-            "url": "",
-            "updateDate": ""
-          }
-        },
-        {
-          "id": "compound_biological_role_chebi",
-          "label": "Biological role",
-          "description": "Classification based on the biological roles, such as inhibitor or antimicrobial agent from ChEBI",
-          "data": "https://integbio.jp/togosite/sparqlist/api/compound_biological_role_chebi",
-          "idType": "chebi",
-          "dataSource": {
-            "label": "",
-            "url": "",
-            "updateDate": ""
-          }
-        },
-        {
-          "id": "compound_drug_indication_mesh_chembl",
-          "label": "Drug indication",
-          "description": "Classification of diseases for which drugs are indicated, based on hierarchical data using MeSH, a life science thesaurus from ChEMBL",
-          "data": "https://integbio.jp/togosite/sparqlist/api/compound_drug_indication_mesh_chembl",
-          "idType": "chembl_compound",
-          "dataSource": {
-            "label": "",
-            "url": "",
-            "updateDate": ""
-          }
-        },
-        {
-          "id": "compound_drug_development_phase_chembl",
-          "label": "Drug development phase",
-          "description": "Classification based on the drug's development phase (research stage, phase I-III, and post-launch) from ChEMBL",
-          "data": "https://integbio.jp/togosite/sparqlist/api/compound_drug_development_phase_chembl",
-          "idType": "chembl_compound",
-          "dataSource": {
-            "label": "",
-            "url": "",
-            "updateDate": ""
-          }
-        },
-        {
-          "id": "compound_atc_classification_pubchem",
-          "label": "PubChem ATC classification",
-          "description": "Classification of a medicine (in PubChem) according to its medicinal properties (WHO ATC Code)",
-          "data": "https://integbio.jp/togosite/sparqlist/api/compound_atc_classification_pubchem",
-          "idType": "pubchem_compound",
-          "dataSource": {
-            "label": "",
-            "url": "",
-            "updateDate": ""
-          }
-        },
-        {
-          "id": "compound_atc_classification_chembl",
-          "label": "ChEMBL ATC classification",
-          "description": "Classification of a medicine (in ChEMBL) according to its medicinal properties (WHO ATC Code)",
-          "data": "https://integbio.jp/togosite/sparqlist/api/compound_atc_classification_chembl",
-          "idType": "chembl_compound",
-          "dataSource": {
-            "label": "",
-            "url": "",
-            "updateDate": ""
-          }
-        }
+        "compound_substance_type_chembl",
+        "compound_chemical_role_chebi",
+        "compound_application_type_chebi",
+        "compound_action_type_chembl",
+        "compound_biological_role_chebi",
+        "compound_drug_indication_mesh_chembl",
+        "compound_drug_development_phase_chembl",
+        "compound_atc_classification_pubchem",
+        "compound_atc_classification_chembl"
       ]
     },
     {
       "id": "disease",
       "label": "Disease",
       "attributes": [
-        {
-          "id": "disease_diseases_mondo",
-          "label": "Diseases in Mondo",
-          "description": "Subcategories in the Disease or disorder category in the Mondo Disease Ontology (Mondo)",
-          "data": "https://integbio.jp/togosite/sparqlist/api/disease_diseases_mondo",
-          "idType": "mondo",
-          "dataSource": {
-            "label": "",
-            "url": "",
-            "updateDate": ""
-          }
-        },
-        {
-          "id": "disease_diseases_mesh",
-          "label": "Diseases in MeSH",
-          "description": "Subcategories in the Disease category in Medical Subject Headings (MeSH)",
-          "data": "https://integbio.jp/togosite/sparqlist/api/disease_diseases_mesh",
-          "idType": "mesh",
-          "dataSource": {
-            "label": "",
-            "url": "",
-            "updateDate": ""
-          }
-        },
-        {
-          "id": "disease_diseases_nando",
-          "label": "Diseases in NANDO",
-          "description": "Japanese rare and intractable disease categories in the Nanbyo Disease Ontology (NANDO)",
-          "data": "https://integbio.jp/togosite/sparqlist/api/disease_diseases_nando",
-          "idType": "nando",
-          "dataSource": {
-            "label": "",
-            "url": "",
-            "updateDate": ""
-          }
-        },
-        {
-          "id": "disease_related_dbs_mondo",
-          "label": "Cross referenced disease DBs in Mondo",
-          "description": "Number of entries linked to Mondo in each of approx. 70 disease related databases from database cross reference in Mondo",
-          "data": "https://integbio.jp/togosite/sparqlist/api/disease_related_dbs_mondo",
-          "idType": "mondo",
-          "dataSource": {
-            "label": "",
-            "url": "",
-            "updateDate": ""
-          }
-        },
-        {
-          "id": "disease_phenotypic_abnormality_hpo",
-          "label": "Phenotypic abnormality",
-          "description": "Classification the subcategories of the Phenotypic abnormality categories of the Human Phenotype Ontology (HPO)",
-          "data": "https://integbio.jp/togosite/sparqlist/api/disease_phenotypic_abnormality_hpo",
-          "idType": "hp",
-          "dataSource": {
-            "label": "",
-            "url": "",
-            "updateDate": ""
-          }
-        }
+        "disease_diseases_mondo",
+        "disease_diseases_mesh",
+        "disease_diseases_nando",
+        "disease_related_dbs_mondo",
+        "disease_phenotypic_abnormality_hpo"
       ]
     },
     {
       "id": "variant",
       "label": "Variant",
       "attributes": [
-        {
-          "id": "variant_gwas_togovar",
-          "label": "GWAS",
-          "description": "Classification of statistically significant variants in genome-wide association studies (GWAS) based on associated traits. Obtained from GWAS catalog via TogoVar",
-          "data": "https://integbio.jp/togosite/sparqlist/api/variant_gwas_togovar",
-          "idType": "togovar",
-          "dataSource": {
-            "label": "",
-            "url": "",
-            "updateDate": ""
-          }
-        },
-        {
-          "id": "variant_clinical_significance_togovar",
-          "label": "Clinical significance",
-          "description": "Classification of variants according to their clinical significance, such as whether they are the cause of the disease or not. Obtained from ClinVar via TogoVar",
-          "data": "https://integbio.jp/togosite/sparqlist/api/variant_clinical_significance_togovar",
-          "idType": "togovar",
-          "dataSource": {
-            "label": "",
-            "url": "",
-            "updateDate": ""
-          }
-        }
+        "variant_gwas_togovar",
+        "variant_clinical_significance_togovar"
       ]
     }
   ],
+  "attributes": {
+    "gene_biotype_ensembl": {
+      "label": "Gene biotype",
+      "description": "Gene or transcript classification annotated in Ensembl",
+      "data": "https://integbio.jp/togosite/sparqlist/api/gene_biotype_ensembl",
+      "idType": "ensembl_gene",
+      "dataSource": {
+        "label": "Ensembl",
+        "url": "http://nov2020.archive.ensembl.org/Homo_sapiens/Info/Index",
+        "updateDate": "14 Jul, 2021"
+      }
+    },
+    "gene_chromosome_ensembl": {
+      "label": "Chromosome",
+      "description": "Chromosome where a gene is located",
+      "data": "https://integbio.jp/togosite/sparqlist/api/gene_chromosome_ensembl",
+      "idType": "ensembl_gene",
+      "dataSource": {
+        "label": "Ensembl human release 102",
+        "url": "http://nov2020.archive.ensembl.org/Homo_sapiens/Info/Index",
+        "updateDate": "14 Jul, 2021"
+      }
+    },
+    "gene_number_of_exons_ensembl": {
+      "label": "# of exons",
+      "description": "Number of exons for each transcript of each gene",
+      "data": "https://integbio.jp/togosite/sparqlist/api/gene_number_of_exons_ensembl",
+      "idType": "ensembl_transcript",
+      "dataSource": {
+        "label": "Ensembl human release 102",
+        "url": "http://nov2020.archive.ensembl.org/Homo_sapiens/Info/Index",
+        "updateDate": "14 Jul, 2021"
+      }
+    },
+    "gene_number_of_paralogs_homologene": {
+      "label": "# of paralogs",
+      "description": "Number of duplicated genes (paralogs) in each human gene calculated based on HomoloGene",
+      "data": "https://integbio.jp/togosite/sparqlist/api/gene_number_of_paralogs_homologene",
+      "idType": "ncbigene",
+      "dataSource": {
+        "label": "HomoloGene",
+        "url": "https://www.ncbi.nlm.nih.gov/homologene/statistics/",
+        "updateDate": "14 Jul, 2021"
+      }
+    },
+    "gene_evolutionary_conservation_homologene": {
+      "label": "Evolutionary divergence",
+      "description": "Most distant organisms from human that have orthologous genes in HomoloGene",
+      "data": "https://integbio.jp/togosite/sparqlist/api/gene_evolutionary_conservation_homologene",
+      "idType": "ncbigene",
+      "dataSource": {
+        "label": "HomoloGene",
+        "url": "https://www.ncbi.nlm.nih.gov/homologene/statistics/",
+        "updateDate": "14 Jul, 2021"
+      }
+    },
+    "gene_high_level_expression_refex": {
+      "label": "High-level expression",
+      "description": "Tissues in which a gene was tissue-specific highly expressed only in one of 34 tissues of RefEx",
+      "data": "https://integbio.jp/togosite/sparqlist/api/gene_high_level_expression_refex",
+      "idType": "ncbigene",
+      "dataSource": {
+        "label": "Calculations for tissue specificity of genechip human GSE7307 from RefEx",
+        "url": "https://doi.org/10.6084/m9.figshare.4028700.v3",
+        "updateDate": "14 Jul, 2021"
+      }
+    },
+    "gene_low_level_expression_refex": {
+      "label": "Low-level expression",
+      "description": "Tissues in which a gene was tissue-specific lowly expressed only in one of 34 tissues of RefEx",
+      "data": "https://integbio.jp/togosite/sparqlist/api/gene_low_level_expression_refex",
+      "idType": "ncbigene",
+      "dataSource": {
+        "label": "Calculations for tissue specificity of genechip human GSE7307 from RefEx",
+        "url": "https://doi.org/10.6084/m9.figshare.4028700.v3",
+        "updateDate": "14 Jul, 2021"
+      }
+    },
+    "gene_high_level_expression_gtex6": {
+      "label": "Expressed in tissues",
+      "description": "Tissues in which a gene is tissue-specific highly expressed in 48 tissues of GTEx",
+      "data": "https://integbio.jp/togosite/sparqlist/api/gene_high_level_expression_gtex6",
+      "idType": "ensembl_gene",
+      "dataSource": {
+        "label": "Supplementary Table 1 of A systematic survey of human tissue-specific gene expression and splicing reveals new opportunities for therapeutic target identification and evaluation; R. Y. Yang et al.; bioRxiv 311563",
+        "url": "https://doi.org/10.1101/311563",
+        "updateDate": "14 Jul, 2021"
+      }
+    },
+    "gene_not_expressed_in_tissue_gtex": {
+      "label": "Not expressed in tissues",
+      "description": "Tissues in which expression of a gene is not detected in 48 tissues of GTEx",
+      "data": "https://integbio.jp/togosite/sparqlist/api/gene_not_expressed_in_tissues_gtex",
+      "idType": "ensembl_gene",
+      "dataSource": {
+        "label": "Supplementary Table 1 of A systematic survey of human tissue-specific gene expression and splicing reveals new opportunities for therapeutic target identification and evaluation; R. Y. Yang et al.; bioRxiv 311563",
+        "url": "https://doi.org/10.1101/311563",
+        "updateDate": "14 Jul, 2021"
+      }
+    },
+    "gene_transcription_factors_chip_atlas": {
+      "label": "Transcription factors",
+      "description": "Transcription factors with predicted target genes in ChIP-Atlas",
+      "data": "https://integbio.jp/togosite/sparqlist/api/gene_transcription_factors_chip_atlas",
+      "idType": "ensembl_gene",
+      "dataSource": {
+        "label": "ChIP-Atlas",
+        "url": "http://dbarchive.biosciencedbc.jp/kyushu-u/hg38/target/",
+        "updateDate": "14 Jul, 2021"
+      }
+    },
+    "protein_domains_uniprot": {
+      "label": "Protein domains",
+      "description": "Protein domains from UniProt",
+      "data": "https://integbio.jp/togosite/sparqlist/api/protein_domains_uniprot",
+      "idType": "uniprot",
+      "dataSource": {
+        "label": "",
+        "url": "",
+        "updateDate": ""
+      }
+    },
+    "protein_cellular_component_uniprot": {
+      "label": "Cellular component",
+      "description": "Functional annotations (GO terms) derived from the Cellular component category of GeneOntology, which Uniprot has assigned to each human protein with evidence information",
+      "data": "https://integbio.jp/togosite/sparqlist/api/protein_cellular_component_uniprot",
+      "idType": "uniprot",
+      "dataSource": {
+        "label": "",
+        "url": "",
+        "updateDate": ""
+      }
+    },
+    "protein_biological_process_uniprot": {
+      "label": "Biological process",
+      "description": "Functional annotations (GO terms) derived from the Biological process category of GeneOntology, which Uniprot has assigned to each human protein with evidence information",
+      "data": "https://integbio.jp/togosite/sparqlist/api/protein_biological_process_uniprot",
+      "idType": "uniprot",
+      "dataSource": {
+        "label": "",
+        "url": "",
+        "updateDate": ""
+      }
+    },
+    "protein_molecular_function_uniprot": {
+      "label": "Molecular function",
+      "description": "Functional annotations (GO terms) derived from the Molecular function category of GeneOntology, which Uniprot has assigned to each human protein with evidence information",
+      "data": "https://integbio.jp/togosite/sparqlist/api/protein_molecular_function_uniprot",
+      "idType": "uniprot",
+      "dataSource": {
+        "label": "",
+        "url": "",
+        "updateDate": ""
+      }
+    },
+    "protein_ligands_uniprot": {
+      "label": "Ligands",
+      "description": "Classification by non-protein molecules which bind/react with proteins in Function section from UniProt",
+      "data": "https://integbio.jp/togosite/sparqlist/api/protein_ligands_uniprot",
+      "idType": "uniprot",
+      "dataSource": {
+        "label": "",
+        "url": "",
+        "updateDate": ""
+      }
+    },
+    "protein_molecular_mass_uniprot": {
+      "label": "Molecular mass",
+      "description": "Molecular weight of the protein including information from multiple isoforms in Sequences section from UniProt",
+      "data": "https://integbio.jp/togosite/sparqlist/api/protein_molecular_mass_uniprot",
+      "idType": "uniprot",
+      "dataSource": {
+        "label": "",
+        "url": "",
+        "updateDate": ""
+      }
+    },
+    "protein_ptms_uniprot": {
+      "label": "PTMs",
+      "description": "Classification by types of post-translational modifications, including S-S bonds (disulfide bonds) in Amino acid modifications section from UniProt",
+      "data": "https://integbio.jp/togosite/sparqlist/api/protein_ptms_uniprot",
+      "idType": "uniprot",
+      "dataSource": {
+        "label": "",
+        "url": "",
+        "updateDate": ""
+      }
+    },
+    "protein_number_of_transmembrane_domains_uniprot": {
+      "label": "# of transmembrane domains",
+      "description": "Number of transmembrane domains. A group of molecules forming a family, such as channels, may have the same number of domains in Topology section from UniProt",
+      "data": "https://integbio.jp/togosite/sparqlist/api/protein_number_of_transmembrane_domains_uniprot",
+      "idType": "uniprot",
+      "dataSource": {
+        "label": "",
+        "url": "",
+        "updateDate": ""
+      }
+    },
+    "protein_number_of_phosphorylation_sites_uniprot": {
+      "label": "# of phosphorylation sites",
+      "description": "Number of phosphorylation at Ser/Thr/Tyr, which may create an activation state for the protein and acts like a switch in Amino acid modifications section from UniProt",
+      "data": "https://integbio.jp/togosite/sparqlist/api/protein_number_of_phosphorylation_sites_uniprot",
+      "idType": "uniprot",
+      "dataSource": {
+        "label": "",
+        "url": "",
+        "updateDate": ""
+      }
+    },
+    "protein_number_of_glycosylation_sites_uniprot": {
+      "label": "# of glycosylation sites",
+      "description": "Number of glycosylation sites, including N-linked,O-linked and others in Amino acid modifications section from UniProt",
+      "data": "https://integbio.jp/togosite/sparqlist/api/protein_number_of_glycosylation_sites_uniprot",
+      "idType": "uniprot",
+      "dataSource": {
+        "label": "",
+        "url": "",
+        "updateDate": ""
+      }
+    },
+    "protein_disease_related_proteins_uniprot": {
+      "label": "Disease-related proteins",
+      "description": "Disease-related proteins in Pathology & Biotech section from UniProt",
+      "data": "https://integbio.jp/togosite/sparqlist/api/protein_disease_related_proteins_uniprot",
+      "idType": "uniprot",
+      "dataSource": {
+        "label": "",
+        "url": "",
+        "updateDate": ""
+      }
+    },
+    "protein_isolation_source_uniprot": {
+      "label": "Tissues w/expression reported",
+      "description": "Classification based on the name of the tissue from which the clone was isolated in the reference describing the protein sequence in Tissue section from UniProt",
+      "data": "https://integbio.jp/togosite/sparqlist/api/protein_isolation_source_uniprot",
+      "idType": "uniprot",
+      "dataSource": {
+        "label": "",
+        "url": "",
+        "updateDate": ""
+      }
+    },
+    "protein_evidence_of_existence_nextprot": {
+      "label": "Evidence of existence",
+      "description": "Classification by the basis of protein expression, such as whether it has been identified as a protein or transcript in Expression section from neXtProt",
+      "data": "https://integbio.jp/togosite/sparqlist/api/protein_evidence_of_existence_nextprot",
+      "idType": "uniprot",
+      "dataSource": {
+        "label": "",
+        "url": "",
+        "updateDate": ""
+      }
+    },
+    "structure_data_existence_uniprot": {
+      "label": "Structure data existence",
+      "description": "Uniprot entries having 3D structure data in PDB in Structure section from Uniprot",
+      "data": "https://integbio.jp/togosite/sparqlist/api/structure_data_existence_uniprot",
+      "idType": "uniprot",
+      "dataSource": {
+        "label": "",
+        "url": "",
+        "updateDate": ""
+      }
+    },
+    "structure_number_of_alpha_helices_pdb": {
+      "label": "# of alpha-helices",
+      "description": "Number of 'Helix' entities counted in each entry of PDB",
+      "data": "https://integbio.jp/togosite/sparqlist/api/structure_number_of_alpha_helices_pdb",
+      "idType": "pdb",
+      "dataSource": {
+        "label": "",
+        "url": "",
+        "updateDate": ""
+      }
+    },
+    "structure_number_of_beta_sheets_pdb": {
+      "label": "# of beta-sheets",
+      "description": "Number of 'Sheet' entities counted in each entry of PDB",
+      "data": "https://integbio.jp/togosite/sparqlist/api/structure_number_of_beta_sheets_pdb",
+      "idType": "pdb",
+      "dataSource": {
+        "label": "",
+        "url": "",
+        "updateDate": ""
+      }
+    },
+    "structure_number_of_peptides_pdb": {
+      "label": "# of peptides in a PDB entry",
+      "description": "The number of peptides in a PDB entry",
+      "data": "https://integbio.jp/togosite/sparqlist/api/structure_number_of_peptides_pdb",
+      "idType": "pdb",
+      "dataSource": {
+        "label": "",
+        "url": "",
+        "updateDate": ""
+      }
+    },
+    "structure_other_related_molecules_pdb": {
+      "label": "Other related molecules",
+      "description": "Nonpeptide molecules related protein structures including water, metal ions, and low molecular weight compounds such as glycerol used to make crystals",
+      "data": "https://integbio.jp/togosite/sparqlist/api/structure_other_related_molecules_pdb",
+      "idType": "pdb",
+      "dataSource": {
+        "label": "",
+        "url": "",
+        "updateDate": ""
+      }
+    },
+    "structure_analysis_methods_pdb": {
+      "label": "Analysis methods",
+      "description": "Classification by the method used to determine the three-dimensional structure in Experimental method section from PDB",
+      "data": "https://integbio.jp/togosite/sparqlist/api/structure_analysis_methods_pdb",
+      "idType": "pdb",
+      "dataSource": {
+        "label": "",
+        "url": "",
+        "updateDate": ""
+      }
+    },
+    "structure_crystallization_temperature_pdb": {
+      "label": "Crystallization temperature",
+      "description": "Temperature of the crystallization solution obtained in Crystallization Conditions section from PDB",
+      "data": "https://integbio.jp/togosite/sparqlist/api/structure_crystallization_temperature_pdb",
+      "idType": "pdb",
+      "dataSource": {
+        "label": "",
+        "url": "",
+        "updateDate": ""
+      }
+    },
+    "structure_crystallization_ph_pdb": {
+      "label": "Crystallization pH",
+      "description": "pH value of the crystallization solution in Crystallization Conditions section from PDB",
+      "data": "https://integbio.jp/togosite/sparqlist/api/structure_crystallization_ph_pdb",
+      "idType": "pdb",
+      "dataSource": {
+        "label": "",
+        "url": "",
+        "updateDate": ""
+      }
+    },
+    "interaction_proteins_in_pathway_reactome": {
+      "label": "Proteins in pathway",
+      "description": "Proteins participating as components classified by pathway (reaction) from Reactome",
+      "data": "https://integbio.jp/togosite/sparqlist/api/interaction_proteins_in_pathway_reactome",
+      "idType": "uniprot",
+      "dataSource": {
+        "label": "",
+        "url": "",
+        "updateDate": ""
+      }
+    },
+    "interaction_compounds_in_pathway_reactome": {
+      "label": "Compounds in pathway",
+      "description": "Compounds participating as components classified by pathway (reaction) from Reactome",
+      "data": "https://integbio.jp/togosite/sparqlist/api/interaction_compounds_in_pathway_reactome",
+      "idType": "chebi",
+      "dataSource": {
+        "label": "",
+        "url": "",
+        "updateDate": ""
+      }
+    },
+    "interaction_number_of_interacting_proteins_uniprot": {
+      "label": "# of interacting proteins",
+      "description": "Classification of uniprot proteins by the number of target proteins they interact with in Interaction section from UniProt",
+      "data": "https://integbio.jp/togosite/sparqlist/api/interaction_number_of_interacting_proteins_uniprot",
+      "idType": "uniprot",
+      "dataSource": {
+        "label": "",
+        "url": "",
+        "updateDate": ""
+      }
+    },
+    "interaction_chembl_assay_existence_uniprot": {
+      "label": "ChEMBL assay existence",
+      "description": "Uniprot entries classified according to the presence or absence of a method to detect direct protein-compound interactions (ChEMBL assay)",
+      "data": "https://integbio.jp/togosite/sparqlist/api/interaction_chembl_assay_existence_uniprot",
+      "idType": "uniprot",
+      "dataSource": {
+        "label": "",
+        "url": "",
+        "updateDate": ""
+      }
+    },
+    "compound_substance_type_chembl": {
+      "label": "Substance type",
+      "description": "Classification based on the type of drug, such as compound or nucleic acid drugs from ChEMBL",
+      "data": "https://integbio.jp/togosite/sparqlist/api/compound_substance_type_chembl",
+      "idType": "chembl_compound",
+      "dataSource": {
+        "label": "",
+        "url": "",
+        "updateDate": ""
+      }
+    },
+    "compound_chemical_role_chebi": {
+      "label": "Chemical role",
+      "description": "Classification based on the chemical roles, such as antioxidant or environmental contaminant from ChEBI",
+      "data": "https://integbio.jp/togosite/sparqlist/api/compound_chemical_role_chebi",
+      "idType": "chebi",
+      "dataSource": {
+        "label": "",
+        "url": "",
+        "updateDate": ""
+      }
+    },
+    "compound_application_type_chebi": {
+      "label": "Application type",
+      "description": "Classification based on the application types, such as pharmaceutical or pesticide from ChEBI",
+      "data": "https://integbio.jp/togosite/sparqlist/api/compound_application_type_chebi",
+      "idType": "chebi",
+      "dataSource": {
+        "label": "",
+        "url": "",
+        "updateDate": ""
+      }
+    },
+    "compound_action_type_chembl": {
+      "label": "Action type",
+      "description": "Classification based on the mechanism of action, such as an inhibitor or an antagonist from ChEMBL",
+      "data": "https://integbio.jp/togosite/sparqlist/api/compound_action_type_chembl",
+      "idType": "chembl_compound",
+      "dataSource": {
+        "label": "",
+        "url": "",
+        "updateDate": ""
+      }
+    },
+    "compound_biological_role_chebi": {
+      "label": "Biological role",
+      "description": "Classification based on the biological roles, such as inhibitor or antimicrobial agent from ChEBI",
+      "data": "https://integbio.jp/togosite/sparqlist/api/compound_biological_role_chebi",
+      "idType": "chebi",
+      "dataSource": {
+        "label": "",
+        "url": "",
+        "updateDate": ""
+      }
+    },
+    "compound_drug_indication_mesh_chembl": {
+      "label": "Drug indication",
+      "description": "Classification of diseases for which drugs are indicated, based on hierarchical data using MeSH, a life science thesaurus from ChEMBL",
+      "data": "https://integbio.jp/togosite/sparqlist/api/compound_drug_indication_mesh_chembl",
+      "idType": "chembl_compound",
+      "dataSource": {
+        "label": "",
+        "url": "",
+        "updateDate": ""
+      }
+    },
+    "compound_drug_development_phase_chembl": {
+      "label": "Drug development phase",
+      "description": "Classification based on the drug's development phase (research stage, phase I-III, and post-launch) from ChEMBL",
+      "data": "https://integbio.jp/togosite/sparqlist/api/compound_drug_development_phase_chembl",
+      "idType": "chembl_compound",
+      "dataSource": {
+        "label": "",
+        "url": "",
+        "updateDate": ""
+      }
+    },
+    "compound_atc_classification_pubchem": {
+      "label": "PubChem ATC classification",
+      "description": "Classification of a medicine (in PubChem) according to its medicinal properties (WHO ATC Code)",
+      "data": "https://integbio.jp/togosite/sparqlist/api/compound_atc_classification_pubchem",
+      "idType": "pubchem_compound",
+      "dataSource": {
+        "label": "",
+        "url": "",
+        "updateDate": ""
+      }
+    },
+    "compound_atc_classification_chembl": {
+      "label": "ChEMBL ATC classification",
+      "description": "Classification of a medicine (in ChEMBL) according to its medicinal properties (WHO ATC Code)",
+      "data": "https://integbio.jp/togosite/sparqlist/api/compound_atc_classification_chembl",
+      "idType": "chembl_compound",
+      "dataSource": {
+        "label": "",
+        "url": "",
+        "updateDate": ""
+      }
+    },
+    "disease_diseases_mondo": {
+      "label": "Diseases in Mondo",
+      "description": "Subcategories in the Disease or disorder category in the Mondo Disease Ontology (Mondo)",
+      "data": "https://integbio.jp/togosite/sparqlist/api/disease_diseases_mondo",
+      "idType": "mondo",
+      "dataSource": {
+        "label": "",
+        "url": "",
+        "updateDate": ""
+      }
+    },
+    "disease_diseases_mesh": {
+      "label": "Diseases in MeSH",
+      "description": "Subcategories in the Disease category in Medical Subject Headings (MeSH)",
+      "data": "https://integbio.jp/togosite/sparqlist/api/disease_diseases_mesh",
+      "idType": "mesh",
+      "dataSource": {
+        "label": "",
+        "url": "",
+        "updateDate": ""
+      }
+    },
+    "disease_diseases_nando": {
+      "label": "Diseases in NANDO",
+      "description": "Japanese rare and intractable disease categories in the Nanbyo Disease Ontology (NANDO)",
+      "data": "https://integbio.jp/togosite/sparqlist/api/disease_diseases_nando",
+      "idType": "nando",
+      "dataSource": {
+        "label": "",
+        "url": "",
+        "updateDate": ""
+      }
+    },
+    "disease_related_dbs_mondo": {
+      "label": "Cross referenced disease DBs in Mondo",
+      "description": "Number of entries linked to Mondo in each of approx. 70 disease related databases from database cross reference in Mondo",
+      "data": "https://integbio.jp/togosite/sparqlist/api/disease_related_dbs_mondo",
+      "idType": "mondo",
+      "dataSource": {
+        "label": "",
+        "url": "",
+        "updateDate": ""
+      }
+    },
+    "disease_phenotypic_abnormality_hpo": {
+      "label": "Phenotypic abnormality",
+      "description": "Classification the subcategories of the Phenotypic abnormality categories of the Human Phenotype Ontology (HPO)",
+      "data": "https://integbio.jp/togosite/sparqlist/api/disease_phenotypic_abnormality_hpo",
+      "idType": "hp",
+      "dataSource": {
+        "label": "",
+        "url": "",
+        "updateDate": ""
+      }
+    },
+    "variant_gwas_togovar": {
+      "label": "GWAS",
+      "description": "Classification of statistically significant variants in genome-wide association studies (GWAS) based on associated traits. Obtained from GWAS catalog via TogoVar",
+      "data": "https://integbio.jp/togosite/sparqlist/api/variant_gwas_togovar",
+      "idType": "togovar",
+      "dataSource": {
+        "label": "",
+        "url": "",
+        "updateDate": ""
+      }
+    },
+    "variant_clinical_significance_togovar": {
+      "label": "Clinical significance",
+      "description": "Classification of variants according to their clinical significance, such as whether they are the cause of the disease or not. Obtained from ClinVar via TogoVar",
+      "data": "https://integbio.jp/togosite/sparqlist/api/variant_clinical_significance_togovar",
+      "idType": "togovar",
+      "dataSource": {
+        "label": "",
+        "url": "",
+        "updateDate": ""
+      }
+    }
+  },
   "idTypes": {
     "ensembl_gene": {
       "label": "Ensembl gene",

--- a/config/togosite-human/attributes.json
+++ b/config/togosite-human/attributes.json
@@ -9,7 +9,7 @@
           "label": "Gene biotype",
           "description": "Gene or transcript classification annotated in Ensembl",
           "data": "https://integbio.jp/togosite/sparqlist/api/gene_biotype_ensembl",
-          "type": "ensembl_gene",
+          "idType": "ensembl_gene",
           "dataSource": {
             "label": "Ensembl",
             "url": "http://nov2020.archive.ensembl.org/Homo_sapiens/Info/Index",
@@ -21,7 +21,7 @@
           "label": "Chromosome",
           "description": "Chromosome where a gene is located",
           "data": "https://integbio.jp/togosite/sparqlist/api/gene_chromosome_ensembl",
-          "type": "ensembl_gene",
+          "idType": "ensembl_gene",
           "dataSource": {
             "label": "Ensembl human release 102",
             "url": "http://nov2020.archive.ensembl.org/Homo_sapiens/Info/Index",
@@ -33,7 +33,7 @@
           "label": "# of exons",
           "description": "Number of exons for each transcript of each gene",
           "data": "https://integbio.jp/togosite/sparqlist/api/gene_number_of_exons_ensembl",
-          "type": "ensembl_transcript",
+          "idType": "ensembl_transcript",
           "dataSource": {
             "label": "Ensembl human release 102",
             "url": "http://nov2020.archive.ensembl.org/Homo_sapiens/Info/Index",
@@ -45,7 +45,7 @@
           "label": "# of paralogs",
           "description": "Number of duplicated genes (paralogs) in each human gene calculated based on HomoloGene",
           "data": "https://integbio.jp/togosite/sparqlist/api/gene_number_of_paralogs_homologene",
-          "type": "ncbigene",
+          "idType": "ncbigene",
           "dataSource": {
             "label": "HomoloGene",
             "url": "https://www.ncbi.nlm.nih.gov/homologene/statistics/",
@@ -57,7 +57,7 @@
           "label": "Evolutionary divergence",
           "description": "Most distant organisms from human that have orthologous genes in HomoloGene",
           "data": "https://integbio.jp/togosite/sparqlist/api/gene_evolutionary_conservation_homologene",
-          "type": "ncbigene",
+          "idType": "ncbigene",
           "dataSource": {
             "label": "HomoloGene",
             "url": "https://www.ncbi.nlm.nih.gov/homologene/statistics/",
@@ -69,7 +69,7 @@
           "label": "High-level expression",
           "description": "Tissues in which a gene was tissue-specific highly expressed only in one of 34 tissues of RefEx",
           "data": "https://integbio.jp/togosite/sparqlist/api/gene_high_level_expression_refex",
-          "type": "ncbigene",
+          "idType": "ncbigene",
           "dataSource": {
             "label": "Calculations for tissue specificity of genechip human GSE7307 from RefEx",
             "url": "https://doi.org/10.6084/m9.figshare.4028700.v3",
@@ -81,7 +81,7 @@
           "label": "Low-level expression",
           "description": "Tissues in which a gene was tissue-specific lowly expressed only in one of 34 tissues of RefEx",
           "data": "https://integbio.jp/togosite/sparqlist/api/gene_low_level_expression_refex",
-          "type": "ncbigene",
+          "idType": "ncbigene",
           "dataSource": {
             "label": "Calculations for tissue specificity of genechip human GSE7307 from RefEx",
             "url": "https://doi.org/10.6084/m9.figshare.4028700.v3",
@@ -93,7 +93,7 @@
           "label": "Expressed in tissues",
           "description": "Tissues in which a gene is tissue-specific highly expressed in 48 tissues of GTEx",
           "data": "https://integbio.jp/togosite/sparqlist/api/gene_high_level_expression_gtex6",
-          "type": "ensembl_gene",
+          "idType": "ensembl_gene",
           "dataSource": {
             "label": "Supplementary Table 1 of A systematic survey of human tissue-specific gene expression and splicing reveals new opportunities for therapeutic target identification and evaluation; R. Y. Yang et al.; bioRxiv 311563",
             "url": "https://doi.org/10.1101/311563",
@@ -105,7 +105,7 @@
           "label": "Not expressed in tissues",
           "description": "Tissues in which expression of a gene is not detected in 48 tissues of GTEx",
           "data": "https://integbio.jp/togosite/sparqlist/api/gene_not_expressed_in_tissues_gtex",
-          "type": "ensembl_gene",
+          "idType": "ensembl_gene",
           "dataSource": {
             "label": "Supplementary Table 1 of A systematic survey of human tissue-specific gene expression and splicing reveals new opportunities for therapeutic target identification and evaluation; R. Y. Yang et al.; bioRxiv 311563",
             "url": "https://doi.org/10.1101/311563",
@@ -117,7 +117,7 @@
           "label": "Transcription factors",
           "description": "Transcription factors with predicted target genes in ChIP-Atlas",
           "data": "https://integbio.jp/togosite/sparqlist/api/gene_transcription_factors_chip_atlas",
-          "type": "ensembl_gene",
+          "idType": "ensembl_gene",
           "dataSource": {
             "label": "ChIP-Atlas",
             "url": "http://dbarchive.biosciencedbc.jp/kyushu-u/hg38/target/",
@@ -135,7 +135,7 @@
           "label": "Protein domains",
           "description": "Protein domains from UniProt",
           "data": "https://integbio.jp/togosite/sparqlist/api/protein_domains_uniprot",
-          "type": "uniprot",
+          "idType": "uniprot",
           "dataSource": {
             "label": "",
             "url": "",
@@ -147,7 +147,7 @@
           "label": "Cellular component",
           "description": "Functional annotations (GO terms) derived from the Cellular component category of GeneOntology, which Uniprot has assigned to each human protein with evidence information",
           "data": "https://integbio.jp/togosite/sparqlist/api/protein_cellular_component_uniprot",
-          "type": "uniprot",
+          "idType": "uniprot",
           "dataSource": {
             "label": "",
             "url": "",
@@ -159,7 +159,7 @@
           "label": "Biological process",
           "description": "Functional annotations (GO terms) derived from the Biological process category of GeneOntology, which Uniprot has assigned to each human protein with evidence information",
           "data": "https://integbio.jp/togosite/sparqlist/api/protein_biological_process_uniprot",
-          "type": "uniprot",
+          "idType": "uniprot",
           "dataSource": {
             "label": "",
             "url": "",
@@ -171,7 +171,7 @@
           "label": "Molecular function",
           "description": "Functional annotations (GO terms) derived from the Molecular function category of GeneOntology, which Uniprot has assigned to each human protein with evidence information",
           "data": "https://integbio.jp/togosite/sparqlist/api/protein_molecular_function_uniprot",
-          "type": "uniprot",
+          "idType": "uniprot",
           "dataSource": {
             "label": "",
             "url": "",
@@ -183,7 +183,7 @@
           "label": "Ligands",
           "description": "Classification by non-protein molecules which bind/react with proteins in Function section from UniProt",
           "data": "https://integbio.jp/togosite/sparqlist/api/protein_ligands_uniprot",
-          "type": "uniprot",
+          "idType": "uniprot",
           "dataSource": {
             "label": "",
             "url": "",
@@ -195,7 +195,7 @@
           "label": "Molecular mass",
           "description": "Molecular weight of the protein including information from multiple isoforms in Sequences section from UniProt",
           "data": "https://integbio.jp/togosite/sparqlist/api/protein_molecular_mass_uniprot",
-          "type": "uniprot",
+          "idType": "uniprot",
           "dataSource": {
             "label": "",
             "url": "",
@@ -207,7 +207,7 @@
           "label": "PTMs",
           "description": "Classification by types of post-translational modifications, including S-S bonds (disulfide bonds) in Amino acid modifications section from UniProt",
           "data": "https://integbio.jp/togosite/sparqlist/api/protein_ptms_uniprot",
-          "type": "uniprot",
+          "idType": "uniprot",
           "dataSource": {
             "label": "",
             "url": "",
@@ -219,7 +219,7 @@
           "label": "# of transmembrane domains",
           "description": "Number of transmembrane domains. A group of molecules forming a family, such as channels, may have the same number of domains in Topology section from UniProt",
           "data": "https://integbio.jp/togosite/sparqlist/api/protein_number_of_transmembrane_domains_uniprot",
-          "type": "uniprot",
+          "idType": "uniprot",
           "dataSource": {
             "label": "",
             "url": "",
@@ -231,7 +231,7 @@
           "label": "# of phosphorylation sites",
           "description": "Number of phosphorylation at Ser/Thr/Tyr, which may create an activation state for the protein and acts like a switch in Amino acid modifications section from UniProt",
           "data": "https://integbio.jp/togosite/sparqlist/api/protein_number_of_phosphorylation_sites_uniprot",
-          "type": "uniprot",
+          "idType": "uniprot",
           "dataSource": {
             "label": "",
             "url": "",
@@ -243,7 +243,7 @@
           "label": "# of glycosylation sites",
           "description": "Number of glycosylation sites, including N-linked,O-linked and others in Amino acid modifications section from UniProt",
           "data": "https://integbio.jp/togosite/sparqlist/api/protein_number_of_glycosylation_sites_uniprot",
-          "type": "uniprot",
+          "idType": "uniprot",
           "dataSource": {
             "label": "",
             "url": "",
@@ -255,7 +255,7 @@
           "label": "Disease-related proteins",
           "description": "Disease-related proteins in Pathology & Biotech section from UniProt",
           "data": "https://integbio.jp/togosite/sparqlist/api/protein_disease_related_proteins_uniprot",
-          "type": "uniprot",
+          "idType": "uniprot",
           "dataSource": {
             "label": "",
             "url": "",
@@ -267,7 +267,7 @@
           "label": "Tissues w/expression reported",
           "description": "Classification based on the name of the tissue from which the clone was isolated in the reference describing the protein sequence in Tissue section from UniProt",
           "data": "https://integbio.jp/togosite/sparqlist/api/protein_isolation_source_uniprot",
-          "type": "uniprot",
+          "idType": "uniprot",
           "dataSource": {
             "label": "",
             "url": "",
@@ -279,7 +279,7 @@
           "label": "Evidence of existence",
           "description": "Classification by the basis of protein expression, such as whether it has been identified as a protein or transcript in Expression section from neXtProt",
           "data": "https://integbio.jp/togosite/sparqlist/api/protein_evidence_of_existence_nextprot",
-          "type": "uniprot",
+          "idType": "uniprot",
           "dataSource": {
             "label": "",
             "url": "",
@@ -297,7 +297,7 @@
           "label": "Structure data existence",
           "description": "Uniprot entries having 3D structure data in PDB in Structure section from Uniprot",
           "data": "https://integbio.jp/togosite/sparqlist/api/structure_data_existence_uniprot",
-          "type": "uniprot",
+          "idType": "uniprot",
           "dataSource": {
             "label": "",
             "url": "",
@@ -309,7 +309,7 @@
           "label": "# of alpha-helices",
           "description": "Number of 'Helix' entities counted in each entry of PDB",
           "data": "https://integbio.jp/togosite/sparqlist/api/structure_number_of_alpha_helices_pdb",
-          "type": "pdb",
+          "idType": "pdb",
           "dataSource": {
             "label": "",
             "url": "",
@@ -321,7 +321,7 @@
           "label": "# of beta-sheets",
           "description": "Number of 'Sheet' entities counted in each entry of PDB",
           "data": "https://integbio.jp/togosite/sparqlist/api/structure_number_of_beta_sheets_pdb",
-          "type": "pdb",
+          "idType": "pdb",
           "dataSource": {
             "label": "",
             "url": "",
@@ -333,7 +333,7 @@
           "label": "# of peptides in a PDB entry",
           "description": "The number of peptides in a PDB entry",
           "data": "https://integbio.jp/togosite/sparqlist/api/structure_number_of_peptides_pdb",
-          "type": "pdb",
+          "idType": "pdb",
           "dataSource": {
             "label": "",
             "url": "",
@@ -345,7 +345,7 @@
           "label": "Other related molecules",
           "description": "Nonpeptide molecules related protein structures including water, metal ions, and low molecular weight compounds such as glycerol used to make crystals",
           "data": "https://integbio.jp/togosite/sparqlist/api/structure_other_related_molecules_pdb",
-          "type": "pdb",
+          "idType": "pdb",
           "dataSource": {
             "label": "",
             "url": "",
@@ -357,7 +357,7 @@
           "label": "Analysis methods",
           "description": "Classification by the method used to determine the three-dimensional structure in Experimental method section from PDB",
           "data": "https://integbio.jp/togosite/sparqlist/api/structure_analysis_methods_pdb",
-          "type": "pdb",
+          "idType": "pdb",
           "dataSource": {
             "label": "",
             "url": "",
@@ -369,7 +369,7 @@
           "label": "Crystallization temperature",
           "description": "Temperature of the crystallization solution obtained in Crystallization Conditions section from PDB",
           "data": "https://integbio.jp/togosite/sparqlist/api/structure_crystallization_temperature_pdb",
-          "type": "pdb",
+          "idType": "pdb",
           "dataSource": {
             "label": "",
             "url": "",
@@ -381,7 +381,7 @@
           "label": "Crystallization pH",
           "description": "pH value of the crystallization solution in Crystallization Conditions section from PDB",
           "data": "https://integbio.jp/togosite/sparqlist/api/structure_crystallization_ph_pdb",
-          "type": "pdb",
+          "idType": "pdb",
           "dataSource": {
             "label": "",
             "url": "",
@@ -399,7 +399,7 @@
           "label": "Proteins in pathway",
           "description": "Proteins participating as components classified by pathway (reaction) from Reactome",
           "data": "https://integbio.jp/togosite/sparqlist/api/interaction_proteins_in_pathway_reactome",
-          "type": "uniprot",
+          "idType": "uniprot",
           "dataSource": {
             "label": "",
             "url": "",
@@ -411,7 +411,7 @@
           "label": "Compounds in pathway",
           "description": "Compounds participating as components classified by pathway (reaction) from Reactome",
           "data": "https://integbio.jp/togosite/sparqlist/api/interaction_compounds_in_pathway_reactome",
-          "type": "chebi",
+          "idType": "chebi",
           "dataSource": {
             "label": "",
             "url": "",
@@ -423,7 +423,7 @@
           "label": "# of interacting proteins",
           "description": "Classification of uniprot proteins by the number of target proteins they interact with in Interaction section from UniProt",
           "data": "https://integbio.jp/togosite/sparqlist/api/interaction_number_of_interacting_proteins_uniprot",
-          "type": "uniprot",
+          "idType": "uniprot",
           "dataSource": {
             "label": "",
             "url": "",
@@ -435,7 +435,7 @@
           "label": "ChEMBL assay existence",
           "description": "Uniprot entries classified according to the presence or absence of a method to detect direct protein-compound interactions (ChEMBL assay)",
           "data": "https://integbio.jp/togosite/sparqlist/api/interaction_chembl_assay_existence_uniprot",
-          "type": "uniprot",
+          "idType": "uniprot",
           "dataSource": {
             "label": "",
             "url": "",
@@ -453,7 +453,7 @@
           "label": "Substance type",
           "description": "Classification based on the type of drug, such as compound or nucleic acid drugs from ChEMBL",
           "data": "https://integbio.jp/togosite/sparqlist/api/compound_substance_type_chembl",
-          "type": "chembl_compound",
+          "idType": "chembl_compound",
           "dataSource": {
             "label": "",
             "url": "",
@@ -465,7 +465,7 @@
           "label": "Chemical role",
           "description": "Classification based on the chemical roles, such as antioxidant or environmental contaminant from ChEBI",
           "data": "https://integbio.jp/togosite/sparqlist/api/compound_chemical_role_chebi",
-          "type": "chebi",
+          "idType": "chebi",
           "dataSource": {
             "label": "",
             "url": "",
@@ -477,7 +477,7 @@
           "label": "Application type",
           "description": "Classification based on the application types, such as pharmaceutical or pesticide from ChEBI",
           "data": "https://integbio.jp/togosite/sparqlist/api/compound_application_type_chebi",
-          "type": "chebi",
+          "idType": "chebi",
           "dataSource": {
             "label": "",
             "url": "",
@@ -489,7 +489,7 @@
           "label": "Action type",
           "description": "Classification based on the mechanism of action, such as an inhibitor or an antagonist from ChEMBL",
           "data": "https://integbio.jp/togosite/sparqlist/api/compound_action_type_chembl",
-          "type": "chembl_compound",
+          "idType": "chembl_compound",
           "dataSource": {
             "label": "",
             "url": "",
@@ -501,7 +501,7 @@
           "label": "Biological role",
           "description": "Classification based on the biological roles, such as inhibitor or antimicrobial agent from ChEBI",
           "data": "https://integbio.jp/togosite/sparqlist/api/compound_biological_role_chebi",
-          "type": "chebi",
+          "idType": "chebi",
           "dataSource": {
             "label": "",
             "url": "",
@@ -513,7 +513,7 @@
           "label": "Drug indication",
           "description": "Classification of diseases for which drugs are indicated, based on hierarchical data using MeSH, a life science thesaurus from ChEMBL",
           "data": "https://integbio.jp/togosite/sparqlist/api/compound_drug_indication_mesh_chembl",
-          "type": "chembl_compound",
+          "idType": "chembl_compound",
           "dataSource": {
             "label": "",
             "url": "",
@@ -525,7 +525,7 @@
           "label": "Drug development phase",
           "description": "Classification based on the drug's development phase (research stage, phase I-III, and post-launch) from ChEMBL",
           "data": "https://integbio.jp/togosite/sparqlist/api/compound_drug_development_phase_chembl",
-          "type": "chembl_compound",
+          "idType": "chembl_compound",
           "dataSource": {
             "label": "",
             "url": "",
@@ -537,7 +537,7 @@
           "label": "PubChem ATC classification",
           "description": "Classification of a medicine (in PubChem) according to its medicinal properties (WHO ATC Code)",
           "data": "https://integbio.jp/togosite/sparqlist/api/compound_atc_classification_pubchem",
-          "type": "pubchem_compound",
+          "idType": "pubchem_compound",
           "dataSource": {
             "label": "",
             "url": "",
@@ -549,7 +549,7 @@
           "label": "ChEMBL ATC classification",
           "description": "Classification of a medicine (in ChEMBL) according to its medicinal properties (WHO ATC Code)",
           "data": "https://integbio.jp/togosite/sparqlist/api/compound_atc_classification_chembl",
-          "type": "chembl_compound",
+          "idType": "chembl_compound",
           "dataSource": {
             "label": "",
             "url": "",
@@ -567,7 +567,7 @@
           "label": "Diseases in Mondo",
           "description": "Subcategories in the Disease or disorder category in the Mondo Disease Ontology (Mondo)",
           "data": "https://integbio.jp/togosite/sparqlist/api/disease_diseases_mondo",
-          "type": "mondo",
+          "idType": "mondo",
           "dataSource": {
             "label": "",
             "url": "",
@@ -579,7 +579,7 @@
           "label": "Diseases in MeSH",
           "description": "Subcategories in the Disease category in Medical Subject Headings (MeSH)",
           "data": "https://integbio.jp/togosite/sparqlist/api/disease_diseases_mesh",
-          "type": "mesh",
+          "idType": "mesh",
           "dataSource": {
             "label": "",
             "url": "",
@@ -591,7 +591,7 @@
           "label": "Diseases in NANDO",
           "description": "Japanese rare and intractable disease categories in the Nanbyo Disease Ontology (NANDO)",
           "data": "https://integbio.jp/togosite/sparqlist/api/disease_diseases_nando",
-          "type": "nando",
+          "idType": "nando",
           "dataSource": {
             "label": "",
             "url": "",
@@ -603,7 +603,7 @@
           "label": "Cross referenced disease DBs in Mondo",
           "description": "Number of entries linked to Mondo in each of approx. 70 disease related databases from database cross reference in Mondo",
           "data": "https://integbio.jp/togosite/sparqlist/api/disease_related_dbs_mondo",
-          "type": "mondo",
+          "idType": "mondo",
           "dataSource": {
             "label": "",
             "url": "",
@@ -615,7 +615,7 @@
           "label": "Phenotypic abnormality",
           "description": "Classification the subcategories of the Phenotypic abnormality categories of the Human Phenotype Ontology (HPO)",
           "data": "https://integbio.jp/togosite/sparqlist/api/disease_phenotypic_abnormality_hpo",
-          "type": "hp",
+          "idType": "hp",
           "dataSource": {
             "label": "",
             "url": "",
@@ -633,7 +633,7 @@
           "label": "GWAS",
           "description": "Classification of statistically significant variants in genome-wide association studies (GWAS) based on associated traits. Obtained from GWAS catalog via TogoVar",
           "data": "https://integbio.jp/togosite/sparqlist/api/variant_gwas_togovar",
-          "type": "togovar",
+          "idType": "togovar",
           "dataSource": {
             "label": "",
             "url": "",
@@ -645,7 +645,7 @@
           "label": "Clinical significance",
           "description": "Classification of variants according to their clinical significance, such as whether they are the cause of the disease or not. Obtained from ClinVar via TogoVar",
           "data": "https://integbio.jp/togosite/sparqlist/api/variant_clinical_significance_togovar",
-          "type": "togovar",
+          "idType": "togovar",
           "dataSource": {
             "label": "",
             "url": "",
@@ -655,71 +655,253 @@
       ]
     }
   ],
-  "identifiers": {
+  "idTypes": {
     "ensembl_gene": {
       "label": "Ensembl gene",
       "template": "https://raw.githubusercontent.com/dbcls/togosite/develop/config/togosite-human/templates/ensembl_gene.hbs",
-      "target": true
+      "target": true,
+      "conversion": {
+        "ensembl_transcript": "https://api.togoid.jp/convert?format=json&route=ensembl_gene,ensembl_transcript",
+        "ncbigene": "https://api.togoid.jp/convert?format=json&route=ensembl_gene,ncbigene",
+        "uniprot": "https://api.togoid.jp/convert?format=json&route=ensembl_gene,uniprot",
+        "pdb": "https://api.togoid.jp/convert?format=json&route=ensembl_gene,pdb",
+        "chebi": "https://api.togoid.jp/convert?format=json&route=ensembl_gene,chebi",
+        "chembl_compound": "https://api.togoid.jp/convert?format=json&route=ensembl_gene,chembl_compound",
+        "pubchem_compound": "https://api.togoid.jp/convert?format=json&route=ensembl_gene,pubchem_compound",
+        "mondo": "https://api.togoid.jp/convert?format=json&route=ensembl_gene,mondo",
+        "mesh": "https://api.togoid.jp/convert?format=json&route=ensembl_gene,mesh",
+        "nando": "https://api.togoid.jp/convert?format=json&route=ensembl_gene,nando",
+        "hp": "https://api.togoid.jp/convert?format=json&route=ensembl_gene,hp",
+        "togovar": "https://api.togoid.jp/convert?format=json&route=ensembl_gene,togovar"
+      }
     },
     "ensembl_transcript": {
       "label": "Ensembl transcript",
       "template": "https://raw.githubusercontent.com/dbcls/togosite/develop/config/togosite-human/templates/ensembl_transcript.hbs",
-      "target": true
+      "target": true,
+      "conversion": {
+        "ensembl_gene": "https://api.togoid.jp/convert?format=json&route=ensembl_transcript,ensembl_gene",
+        "ncbigene": "https://api.togoid.jp/convert?format=json&route=ensembl_transcript,ncbigene",
+        "uniprot": "https://api.togoid.jp/convert?format=json&route=ensembl_transcript,uniprot",
+        "pdb": "https://api.togoid.jp/convert?format=json&route=ensembl_transcript,pdb",
+        "chebi": "https://api.togoid.jp/convert?format=json&route=ensembl_transcript,chebi",
+        "chembl_compound": "https://api.togoid.jp/convert?format=json&route=ensembl_transcript,chembl_compound",
+        "pubchem_compound": "https://api.togoid.jp/convert?format=json&route=ensembl_transcript,pubchem_compound",
+        "mondo": "https://api.togoid.jp/convert?format=json&route=ensembl_transcript,mondo",
+        "mesh": "https://api.togoid.jp/convert?format=json&route=ensembl_transcript,mesh",
+        "nando": "https://api.togoid.jp/convert?format=json&route=ensembl_transcript,nando",
+        "hp": "https://api.togoid.jp/convert?format=json&route=ensembl_transcript,hp",
+        "togovar": "https://api.togoid.jp/convert?format=json&route=ensembl_transcript,togovar"
+      }
     },
     "ncbigene": {
       "label": "NCBI gene",
       "template": "https://raw.githubusercontent.com/dbcls/togosite/develop/config/togosite-human/templates/ncbigene.hbs",
-      "target": true
+      "target": true,
+      "conversion": {
+        "ensembl_gene": "https://api.togoid.jp/convert?format=json&route=ncbigene,ensembl_gene",
+        "ensembl_transcript": "https://api.togoid.jp/convert?format=json&route=ncbigene,ensembl_transcript",
+        "uniprot": "https://api.togoid.jp/convert?format=json&route=ncbigene,uniprot",
+        "pdb": "https://api.togoid.jp/convert?format=json&route=ncbigene,pdb",
+        "chebi": "https://api.togoid.jp/convert?format=json&route=ncbigene,chebi",
+        "chembl_compound": "https://api.togoid.jp/convert?format=json&route=ncbigene,chembl_compound",
+        "pubchem_compound": "https://api.togoid.jp/convert?format=json&route=ncbigene,pubchem_compound",
+        "mondo": "https://api.togoid.jp/convert?format=json&route=ncbigene,mondo",
+        "mesh": "https://api.togoid.jp/convert?format=json&route=ncbigene,mesh",
+        "nando": "https://api.togoid.jp/convert?format=json&route=ncbigene,nando",
+        "hp": "https://api.togoid.jp/convert?format=json&route=ncbigene,hp",
+        "togovar": "https://api.togoid.jp/convert?format=json&route=ncbigene,togovar"
+      }
     },
     "uniprot": {
       "label": "UniProt",
       "template": "https://raw.githubusercontent.com/dbcls/togosite/develop/config/togosite-human/templates/uniprot.hbs",
-      "target": true
+      "target": true,
+      "conversion": {
+        "ensembl_gene": "https://api.togoid.jp/convert?format=json&route=uniprot,ensembl_gene",
+        "ensembl_transcript": "https://api.togoid.jp/convert?format=json&route=uniprot,ensembl_transcript",
+        "ncbigene": "https://api.togoid.jp/convert?format=json&route=uniprot,ncbigene",
+        "pdb": "https://api.togoid.jp/convert?format=json&route=uniprot,pdb",
+        "chebi": "https://api.togoid.jp/convert?format=json&route=uniprot,chebi",
+        "chembl_compound": "https://api.togoid.jp/convert?format=json&route=uniprot,chembl_compound",
+        "pubchem_compound": "https://api.togoid.jp/convert?format=json&route=uniprot,pubchem_compound",
+        "mondo": "https://api.togoid.jp/convert?format=json&route=uniprot,mondo",
+        "mesh": "https://api.togoid.jp/convert?format=json&route=uniprot,mesh",
+        "nando": "https://api.togoid.jp/convert?format=json&route=uniprot,nando",
+        "hp": "https://api.togoid.jp/convert?format=json&route=uniprot,hp",
+        "togovar": "https://api.togoid.jp/convert?format=json&route=uniprot,togovar"
+      }
     },
     "pdb": {
       "label": "PDB",
       "template": "https://raw.githubusercontent.com/dbcls/togosite/develop/config/togosite-human/templates/pdb.hbs",
-      "target": true
+      "target": true,
+      "conversion": {
+        "ensembl_gene": "https://api.togoid.jp/convert?format=json&route=pdb,ensembl_gene",
+        "ensembl_transcript": "https://api.togoid.jp/convert?format=json&route=pdb,ensembl_transcript",
+        "ncbigene": "https://api.togoid.jp/convert?format=json&route=pdb,ncbigene",
+        "uniprot": "https://api.togoid.jp/convert?format=json&route=pdb,uniprot",
+        "chebi": "https://api.togoid.jp/convert?format=json&route=pdb,chebi",
+        "chembl_compound": "https://api.togoid.jp/convert?format=json&route=pdb,chembl_compound",
+        "pubchem_compound": "https://api.togoid.jp/convert?format=json&route=pdb,pubchem_compound",
+        "mondo": "https://api.togoid.jp/convert?format=json&route=pdb,mondo",
+        "mesh": "https://api.togoid.jp/convert?format=json&route=pdb,mesh",
+        "nando": "https://api.togoid.jp/convert?format=json&route=pdb,nando",
+        "hp": "https://api.togoid.jp/convert?format=json&route=pdb,hp",
+        "togovar": "https://api.togoid.jp/convert?format=json&route=pdb,togovar"
+      }
     },
     "chebi": {
       "label": "ChEBI compound",
       "template": "https://raw.githubusercontent.com/dbcls/togosite/develop/config/togosite-human/templates/chebi.hbs",
-      "target": true
+      "target": true,
+      "conversion": {
+        "ensembl_gene": "https://api.togoid.jp/convert?format=json&route=chebi,ensembl_gene",
+        "ensembl_transcript": "https://api.togoid.jp/convert?format=json&route=chebi,ensembl_transcript",
+        "ncbigene": "https://api.togoid.jp/convert?format=json&route=chebi,ncbigene",
+        "uniprot": "https://api.togoid.jp/convert?format=json&route=chebi,uniprot",
+        "pdb": "https://api.togoid.jp/convert?format=json&route=chebi,pdb",
+        "chembl_compound": "https://api.togoid.jp/convert?format=json&route=chebi,chembl_compound",
+        "pubchem_compound": "https://api.togoid.jp/convert?format=json&route=chebi,pubchem_compound",
+        "mondo": "https://api.togoid.jp/convert?format=json&route=chebi,mondo",
+        "mesh": "https://api.togoid.jp/convert?format=json&route=chebi,mesh",
+        "nando": "https://api.togoid.jp/convert?format=json&route=chebi,nando",
+        "hp": "https://api.togoid.jp/convert?format=json&route=chebi,hp",
+        "togovar": "https://api.togoid.jp/convert?format=json&route=chebi,togovar"
+      }
     },
     "chembl_compound": {
       "label": "ChEMBL compound",
       "template": "https://raw.githubusercontent.com/dbcls/togosite/develop/config/togosite-human/templates/chembl_compound.hbs",
-      "target": true
+      "target": true,
+      "conversion": {
+        "ensembl_gene": "https://api.togoid.jp/convert?format=json&route=chembl_compound,ensembl_gene",
+        "ensembl_transcript": "https://api.togoid.jp/convert?format=json&route=chembl_compound,ensembl_transcript",
+        "ncbigene": "https://api.togoid.jp/convert?format=json&route=chembl_compound,ncbigene",
+        "uniprot": "https://api.togoid.jp/convert?format=json&route=chembl_compound,uniprot",
+        "pdb": "https://api.togoid.jp/convert?format=json&route=chembl_compound,pdb",
+        "chebi": "https://api.togoid.jp/convert?format=json&route=chembl_compound,chebi",
+        "pubchem_compound": "https://api.togoid.jp/convert?format=json&route=chembl_compound,pubchem_compound",
+        "mondo": "https://api.togoid.jp/convert?format=json&route=chembl_compound,mondo",
+        "mesh": "https://api.togoid.jp/convert?format=json&route=chembl_compound,mesh",
+        "nando": "https://api.togoid.jp/convert?format=json&route=chembl_compound,nando",
+        "hp": "https://api.togoid.jp/convert?format=json&route=chembl_compound,hp",
+        "togovar": "https://api.togoid.jp/convert?format=json&route=chembl_compound,togovar"
+      }
     },
     "pubchem_compound": {
       "label": "PubChem compound",
       "template": "https://raw.githubusercontent.com/dbcls/togosite/develop/config/togosite-human/templates/pubchem_compound.hbs",
-      "target": true
+      "target": true,
+      "conversion": {
+        "ensembl_gene": "https://api.togoid.jp/convert?format=json&route=pubchem_compound,ensembl_gene",
+        "ensembl_transcript": "https://api.togoid.jp/convert?format=json&route=pubchem_compound,ensembl_transcript",
+        "ncbigene": "https://api.togoid.jp/convert?format=json&route=pubchem_compound,ncbigene",
+        "uniprot": "https://api.togoid.jp/convert?format=json&route=pubchem_compound,uniprot",
+        "pdb": "https://api.togoid.jp/convert?format=json&route=pubchem_compound,pdb",
+        "chebi": "https://api.togoid.jp/convert?format=json&route=pubchem_compound,chebi",
+        "chembl_compound": "https://api.togoid.jp/convert?format=json&route=pubchem_compound,chembl_compound",
+        "mondo": "https://api.togoid.jp/convert?format=json&route=pubchem_compound,mondo",
+        "mesh": "https://api.togoid.jp/convert?format=json&route=pubchem_compound,mesh",
+        "nando": "https://api.togoid.jp/convert?format=json&route=pubchem_compound,nando",
+        "hp": "https://api.togoid.jp/convert?format=json&route=pubchem_compound,hp",
+        "togovar": "https://api.togoid.jp/convert?format=json&route=pubchem_compound,togovar"
+      }
     },
     "mondo": {
       "label": "Mondo",
       "template": "https://raw.githubusercontent.com/dbcls/togosite/develop/config/togosite-human/templates/mondo.hbs",
-      "target": true
+      "target": true,
+      "conversion": {
+        "ensembl_gene": "https://api.togoid.jp/convert?format=json&route=mondo,ensembl_gene",
+        "ensembl_transcript": "https://api.togoid.jp/convert?format=json&route=mondo,ensembl_transcript",
+        "ncbigene": "https://api.togoid.jp/convert?format=json&route=mondo,ncbigene",
+        "uniprot": "https://api.togoid.jp/convert?format=json&route=mondo,uniprot",
+        "pdb": "https://api.togoid.jp/convert?format=json&route=mondo,pdb",
+        "chebi": "https://api.togoid.jp/convert?format=json&route=mondo,chebi",
+        "chembl_compound": "https://api.togoid.jp/convert?format=json&route=mondo,chembl_compound",
+        "pubchem_compound": "https://api.togoid.jp/convert?format=json&route=mondo,pubchem_compound",
+        "mesh": "https://api.togoid.jp/convert?format=json&route=mondo,mesh",
+        "nando": "https://api.togoid.jp/convert?format=json&route=mondo,nando",
+        "hp": "https://api.togoid.jp/convert?format=json&route=mondo,hp",
+        "togovar": "https://api.togoid.jp/convert?format=json&route=mondo,togovar"
+      }
     },
     "mesh": {
       "label": "MeSH",
       "template": "https://raw.githubusercontent.com/dbcls/togosite/develop/config/togosite-human/templates/mesh.hbs",
-      "target": true
+      "target": true,
+      "conversion": {
+        "ensembl_gene": "https://api.togoid.jp/convert?format=json&route=mesh,ensembl_gene",
+        "ensembl_transcript": "https://api.togoid.jp/convert?format=json&route=mesh,ensembl_transcript",
+        "ncbigene": "https://api.togoid.jp/convert?format=json&route=mesh,ncbigene",
+        "uniprot": "https://api.togoid.jp/convert?format=json&route=mesh,uniprot",
+        "pdb": "https://api.togoid.jp/convert?format=json&route=mesh,pdb",
+        "chebi": "https://api.togoid.jp/convert?format=json&route=mesh,chebi",
+        "chembl_compound": "https://api.togoid.jp/convert?format=json&route=mesh,chembl_compound",
+        "pubchem_compound": "https://api.togoid.jp/convert?format=json&route=mesh,pubchem_compound",
+        "mondo": "https://api.togoid.jp/convert?format=json&route=mesh,mondo",
+        "nando": "https://api.togoid.jp/convert?format=json&route=mesh,nando",
+        "hp": "https://api.togoid.jp/convert?format=json&route=mesh,hp",
+        "togovar": "https://api.togoid.jp/convert?format=json&route=mesh,togovar"
+      }
     },
     "nando": {
       "label": "NANDO",
       "template": "https://raw.githubusercontent.com/dbcls/togosite/develop/config/togosite-human/templates/nando.hbs",
-      "target": true
+      "target": true,
+      "conversion": {
+        "ensembl_gene": "https://api.togoid.jp/convert?format=json&route=nando,ensembl_gene",
+        "ensembl_transcript": "https://api.togoid.jp/convert?format=json&route=nando,ensembl_transcript",
+        "ncbigene": "https://api.togoid.jp/convert?format=json&route=nando,ncbigene",
+        "uniprot": "https://api.togoid.jp/convert?format=json&route=nando,uniprot",
+        "pdb": "https://api.togoid.jp/convert?format=json&route=nando,pdb",
+        "chebi": "https://api.togoid.jp/convert?format=json&route=nando,chebi",
+        "chembl_compound": "https://api.togoid.jp/convert?format=json&route=nando,chembl_compound",
+        "pubchem_compound": "https://api.togoid.jp/convert?format=json&route=nando,pubchem_compound",
+        "mondo": "https://api.togoid.jp/convert?format=json&route=nando,mondo",
+        "mesh": "https://api.togoid.jp/convert?format=json&route=nando,mesh",
+        "hp": "https://api.togoid.jp/convert?format=json&route=nando,hp",
+        "togovar": "https://api.togoid.jp/convert?format=json&route=nando,togovar"
+      }
     },
     "hp": {
       "label": "Human Phenotype Ontology",
       "template": "https://raw.githubusercontent.com/dbcls/togosite/develop/config/togosite-human/templates/hp.hbs",
-      "target": true
+      "target": true,
+      "conversion": {
+        "ensembl_gene": "https://api.togoid.jp/convert?format=json&route=hp,ensembl_gene",
+        "ensembl_transcript": "https://api.togoid.jp/convert?format=json&route=hp,ensembl_transcript",
+        "ncbigene": "https://api.togoid.jp/convert?format=json&route=hp,ncbigene",
+        "uniprot": "https://api.togoid.jp/convert?format=json&route=hp,uniprot",
+        "pdb": "https://api.togoid.jp/convert?format=json&route=hp,pdb",
+        "chebi": "https://api.togoid.jp/convert?format=json&route=hp,chebi",
+        "chembl_compound": "https://api.togoid.jp/convert?format=json&route=hp,chembl_compound",
+        "pubchem_compound": "https://api.togoid.jp/convert?format=json&route=hp,pubchem_compound",
+        "mondo": "https://api.togoid.jp/convert?format=json&route=hp,mondo",
+        "mesh": "https://api.togoid.jp/convert?format=json&route=hp,mesh",
+        "nando": "https://api.togoid.jp/convert?format=json&route=hp,nando",
+        "togovar": "https://api.togoid.jp/convert?format=json&route=hp,togovar"
+      }
     },
     "togovar": {
       "label": "TogoVar variant",
       "template": "https://raw.githubusercontent.com/dbcls/togosite/develop/config/togosite-human/templates/togovar.hbs",
-      "target": true
+      "target": true,
+      "conversion": {
+        "ensembl_gene": "https://api.togoid.jp/convert?format=json&route=togovar,ensembl_gene",
+        "ensembl_transcript": "https://api.togoid.jp/convert?format=json&route=togovar,ensembl_transcript",
+        "ncbigene": "https://api.togoid.jp/convert?format=json&route=togovar,ncbigene",
+        "uniprot": "https://api.togoid.jp/convert?format=json&route=togovar,uniprot",
+        "pdb": "https://api.togoid.jp/convert?format=json&route=togovar,pdb",
+        "chebi": "https://api.togoid.jp/convert?format=json&route=togovar,chebi",
+        "chembl_compound": "https://api.togoid.jp/convert?format=json&route=togovar,chembl_compound",
+        "pubchem_compound": "https://api.togoid.jp/convert?format=json&route=togovar,pubchem_compound",
+        "mondo": "https://api.togoid.jp/convert?format=json&route=togovar,mondo",
+        "mesh": "https://api.togoid.jp/convert?format=json&route=togovar,mesh",
+        "nando": "https://api.togoid.jp/convert?format=json&route=togovar,nando",
+        "hp": "https://api.togoid.jp/convert?format=json&route=togovar,hp"
+      }
     }
   }
 }

--- a/config/togosite-human/attributes.json
+++ b/config/togosite-human/attributes.json
@@ -1,0 +1,725 @@
+{
+  "categories": [
+    {
+      "id": "gene",
+      "label": "Gene",
+      "attributes": [
+        {
+          "id": "gene_biotype_ensembl",
+          "label": "Gene biotype",
+          "description": "Gene or transcript classification annotated in Ensembl",
+          "data": "https://integbio.jp/togosite/sparqlist/api/gene_biotype_ensembl",
+          "type": "ensembl_gene",
+          "dataSource": {
+            "label": "Ensembl",
+            "url": "http://nov2020.archive.ensembl.org/Homo_sapiens/Info/Index",
+            "updateDate": "14 Jul, 2021"
+          }
+        },
+        {
+          "id": "gene_chromosome_ensembl",
+          "label": "Chromosome",
+          "description": "Chromosome where a gene is located",
+          "data": "https://integbio.jp/togosite/sparqlist/api/gene_chromosome_ensembl",
+          "type": "ensembl_gene",
+          "dataSource": {
+            "label": "Ensembl human release 102",
+            "url": "http://nov2020.archive.ensembl.org/Homo_sapiens/Info/Index",
+            "updateDate": "14 Jul, 2021"
+          }
+        },
+        {
+          "id": "gene_number_of_exons_ensembl",
+          "label": "# of exons",
+          "description": "Number of exons for each transcript of each gene",
+          "data": "https://integbio.jp/togosite/sparqlist/api/gene_number_of_exons_ensembl",
+          "type": "ensembl_transcript",
+          "dataSource": {
+            "label": "Ensembl human release 102",
+            "url": "http://nov2020.archive.ensembl.org/Homo_sapiens/Info/Index",
+            "updateDate": "14 Jul, 2021"
+          }
+        },
+        {
+          "id": "gene_number_of_paralogs_homologene",
+          "label": "# of paralogs",
+          "description": "Number of duplicated genes (paralogs) in each human gene calculated based on HomoloGene",
+          "data": "https://integbio.jp/togosite/sparqlist/api/gene_number_of_paralogs_homologene",
+          "type": "ncbigene",
+          "dataSource": {
+            "label": "HomoloGene",
+            "url": "https://www.ncbi.nlm.nih.gov/homologene/statistics/",
+            "updateDate": "14 Jul, 2021"
+          }
+        },
+        {
+          "id": "gene_evolutionary_conservation_homologene",
+          "label": "Evolutionary divergence",
+          "description": "Most distant organisms from human that have orthologous genes in HomoloGene",
+          "data": "https://integbio.jp/togosite/sparqlist/api/gene_evolutionary_conservation_homologene",
+          "type": "ncbigene",
+          "dataSource": {
+            "label": "HomoloGene",
+            "url": "https://www.ncbi.nlm.nih.gov/homologene/statistics/",
+            "updateDate": "14 Jul, 2021"
+          }
+        },
+        {
+          "id": "gene_high_level_expression_refex",
+          "label": "High-level expression",
+          "description": "Tissues in which a gene was tissue-specific highly expressed only in one of 34 tissues of RefEx",
+          "data": "https://integbio.jp/togosite/sparqlist/api/gene_high_level_expression_refex",
+          "type": "ncbigene",
+          "dataSource": {
+            "label": "Calculations for tissue specificity of genechip human GSE7307 from RefEx",
+            "url": "https://doi.org/10.6084/m9.figshare.4028700.v3",
+            "updateDate": "14 Jul, 2021"
+          }
+        },
+        {
+          "id": "gene_low_level_expression_refex",
+          "label": "Low-level expression",
+          "description": "Tissues in which a gene was tissue-specific lowly expressed only in one of 34 tissues of RefEx",
+          "data": "https://integbio.jp/togosite/sparqlist/api/gene_low_level_expression_refex",
+          "type": "ncbigene",
+          "dataSource": {
+            "label": "Calculations for tissue specificity of genechip human GSE7307 from RefEx",
+            "url": "https://doi.org/10.6084/m9.figshare.4028700.v3",
+            "updateDate": "14 Jul, 2021"
+          }
+        },
+        {
+          "id": "gene_high_level_expression_gtex6",
+          "label": "Expressed in tissues",
+          "description": "Tissues in which a gene is tissue-specific highly expressed in 48 tissues of GTEx",
+          "data": "https://integbio.jp/togosite/sparqlist/api/gene_high_level_expression_gtex6",
+          "type": "ensembl_gene",
+          "dataSource": {
+            "label": "Supplementary Table 1 of A systematic survey of human tissue-specific gene expression and splicing reveals new opportunities for therapeutic target identification and evaluation; R. Y. Yang et al.; bioRxiv 311563",
+            "url": "https://doi.org/10.1101/311563",
+            "updateDate": "14 Jul, 2021"
+          }
+        },
+        {
+          "id": "gene_not_expressed_in_tissue_gtex",
+          "label": "Not expressed in tissues",
+          "description": "Tissues in which expression of a gene is not detected in 48 tissues of GTEx",
+          "data": "https://integbio.jp/togosite/sparqlist/api/gene_not_expressed_in_tissues_gtex",
+          "type": "ensembl_gene",
+          "dataSource": {
+            "label": "Supplementary Table 1 of A systematic survey of human tissue-specific gene expression and splicing reveals new opportunities for therapeutic target identification and evaluation; R. Y. Yang et al.; bioRxiv 311563",
+            "url": "https://doi.org/10.1101/311563",
+            "updateDate": "14 Jul, 2021"
+          }
+        },
+        {
+          "id": "gene_transcription_factors_chip_atlas",
+          "label": "Transcription factors",
+          "description": "Transcription factors with predicted target genes in ChIP-Atlas",
+          "data": "https://integbio.jp/togosite/sparqlist/api/gene_transcription_factors_chip_atlas",
+          "type": "ensembl_gene",
+          "dataSource": {
+            "label": "ChIP-Atlas",
+            "url": "http://dbarchive.biosciencedbc.jp/kyushu-u/hg38/target/",
+            "updateDate": "14 Jul, 2021"
+          }
+        }
+      ]
+    },
+    {
+      "id": "protein",
+      "label": "Protein",
+      "attributes": [
+        {
+          "id": "protein_domains_uniprot",
+          "label": "Protein domains",
+          "description": "Protein domains from UniProt",
+          "data": "https://integbio.jp/togosite/sparqlist/api/protein_domains_uniprot",
+          "type": "uniprot",
+          "dataSource": {
+            "label": "",
+            "url": "",
+            "updateDate": ""
+          }
+        },
+        {
+          "id": "protein_cellular_component_uniprot",
+          "label": "Cellular component",
+          "description": "Functional annotations (GO terms) derived from the Cellular component category of GeneOntology, which Uniprot has assigned to each human protein with evidence information",
+          "data": "https://integbio.jp/togosite/sparqlist/api/protein_cellular_component_uniprot",
+          "type": "uniprot",
+          "dataSource": {
+            "label": "",
+            "url": "",
+            "updateDate": ""
+          }
+        },
+        {
+          "id": "protein_biological_process_uniprot",
+          "label": "Biological process",
+          "description": "Functional annotations (GO terms) derived from the Biological process category of GeneOntology, which Uniprot has assigned to each human protein with evidence information",
+          "data": "https://integbio.jp/togosite/sparqlist/api/protein_biological_process_uniprot",
+          "type": "uniprot",
+          "dataSource": {
+            "label": "",
+            "url": "",
+            "updateDate": ""
+          }
+        },
+        {
+          "id": "protein_molecular_function_uniprot",
+          "label": "Molecular function",
+          "description": "Functional annotations (GO terms) derived from the Molecular function category of GeneOntology, which Uniprot has assigned to each human protein with evidence information",
+          "data": "https://integbio.jp/togosite/sparqlist/api/protein_molecular_function_uniprot",
+          "type": "uniprot",
+          "dataSource": {
+            "label": "",
+            "url": "",
+            "updateDate": ""
+          }
+        },
+        {
+          "id": "protein_ligands_uniprot",
+          "label": "Ligands",
+          "description": "Classification by non-protein molecules which bind/react with proteins in Function section from UniProt",
+          "data": "https://integbio.jp/togosite/sparqlist/api/protein_ligands_uniprot",
+          "type": "uniprot",
+          "dataSource": {
+            "label": "",
+            "url": "",
+            "updateDate": ""
+          }
+        },
+        {
+          "id": "protein_molecular_mass_uniprot",
+          "label": "Molecular mass",
+          "description": "Molecular weight of the protein including information from multiple isoforms in Sequences section from UniProt",
+          "data": "https://integbio.jp/togosite/sparqlist/api/protein_molecular_mass_uniprot",
+          "type": "uniprot",
+          "dataSource": {
+            "label": "",
+            "url": "",
+            "updateDate": ""
+          }
+        },
+        {
+          "id": "protein_ptms_uniprot",
+          "label": "PTMs",
+          "description": "Classification by types of post-translational modifications, including S-S bonds (disulfide bonds) in Amino acid modifications section from UniProt",
+          "data": "https://integbio.jp/togosite/sparqlist/api/protein_ptms_uniprot",
+          "type": "uniprot",
+          "dataSource": {
+            "label": "",
+            "url": "",
+            "updateDate": ""
+          }
+        },
+        {
+          "id": "protein_number_of_transmembrane_domains_uniprot",
+          "label": "# of transmembrane domains",
+          "description": "Number of transmembrane domains. A group of molecules forming a family, such as channels, may have the same number of domains in Topology section from UniProt",
+          "data": "https://integbio.jp/togosite/sparqlist/api/protein_number_of_transmembrane_domains_uniprot",
+          "type": "uniprot",
+          "dataSource": {
+            "label": "",
+            "url": "",
+            "updateDate": ""
+          }
+        },
+        {
+          "id": "protein_number_of_phosphorylation_sites_uniprot",
+          "label": "# of phosphorylation sites",
+          "description": "Number of phosphorylation at Ser/Thr/Tyr, which may create an activation state for the protein and acts like a switch in Amino acid modifications section from UniProt",
+          "data": "https://integbio.jp/togosite/sparqlist/api/protein_number_of_phosphorylation_sites_uniprot",
+          "type": "uniprot",
+          "dataSource": {
+            "label": "",
+            "url": "",
+            "updateDate": ""
+          }
+        },
+        {
+          "id": "protein_number_of_glycosylation_sites_uniprot",
+          "label": "# of glycosylation sites",
+          "description": "Number of glycosylation sites, including N-linked,O-linked and others in Amino acid modifications section from UniProt",
+          "data": "https://integbio.jp/togosite/sparqlist/api/protein_number_of_glycosylation_sites_uniprot",
+          "type": "uniprot",
+          "dataSource": {
+            "label": "",
+            "url": "",
+            "updateDate": ""
+          }
+        },
+        {
+          "id": "protein_disease_related_proteins_uniprot",
+          "label": "Disease-related proteins",
+          "description": "Disease-related proteins in Pathology & Biotech section from UniProt",
+          "data": "https://integbio.jp/togosite/sparqlist/api/protein_disease_related_proteins_uniprot",
+          "type": "uniprot",
+          "dataSource": {
+            "label": "",
+            "url": "",
+            "updateDate": ""
+          }
+        },
+        {
+          "id": "protein_isolation_source_uniprot",
+          "label": "Tissues w/expression reported",
+          "description": "Classification based on the name of the tissue from which the clone was isolated in the reference describing the protein sequence in Tissue section from UniProt",
+          "data": "https://integbio.jp/togosite/sparqlist/api/protein_isolation_source_uniprot",
+          "type": "uniprot",
+          "dataSource": {
+            "label": "",
+            "url": "",
+            "updateDate": ""
+          }
+        },
+        {
+          "id": "protein_evidence_of_existence_nextprot",
+          "label": "Evidence of existence",
+          "description": "Classification by the basis of protein expression, such as whether it has been identified as a protein or transcript in Expression section from neXtProt",
+          "data": "https://integbio.jp/togosite/sparqlist/api/protein_evidence_of_existence_nextprot",
+          "type": "uniprot",
+          "dataSource": {
+            "label": "",
+            "url": "",
+            "updateDate": ""
+          }
+        }
+      ]
+    },
+    {
+      "id": "proteinStructure",
+      "label": "Protein structure",
+      "attributes": [
+        {
+          "id": "structure_data_existence_uniprot",
+          "label": "Structure data existence",
+          "description": "Uniprot entries having 3D structure data in PDB in Structure section from Uniprot",
+          "data": "https://integbio.jp/togosite/sparqlist/api/structure_data_existence_uniprot",
+          "type": "uniprot",
+          "dataSource": {
+            "label": "",
+            "url": "",
+            "updateDate": ""
+          }
+        },
+        {
+          "id": "structure_number_of_alpha_helices_pdb",
+          "label": "# of alpha-helices",
+          "description": "Number of 'Helix' entities counted in each entry of PDB",
+          "data": "https://integbio.jp/togosite/sparqlist/api/structure_number_of_alpha_helices_pdb",
+          "type": "pdb",
+          "dataSource": {
+            "label": "",
+            "url": "",
+            "updateDate": ""
+          }
+        },
+        {
+          "id": "structure_number_of_beta_sheets_pdb",
+          "label": "# of beta-sheets",
+          "description": "Number of 'Sheet' entities counted in each entry of PDB",
+          "data": "https://integbio.jp/togosite/sparqlist/api/structure_number_of_beta_sheets_pdb",
+          "type": "pdb",
+          "dataSource": {
+            "label": "",
+            "url": "",
+            "updateDate": ""
+          }
+        },
+        {
+          "id": "structure_number_of_peptides_pdb",
+          "label": "# of peptides in a PDB entry",
+          "description": "The number of peptides in a PDB entry",
+          "data": "https://integbio.jp/togosite/sparqlist/api/structure_number_of_peptides_pdb",
+          "type": "pdb",
+          "dataSource": {
+            "label": "",
+            "url": "",
+            "updateDate": ""
+          }
+        },
+        {
+          "id": "structure_other_related_molecules_pdb",
+          "label": "Other related molecules",
+          "description": "Nonpeptide molecules related protein structures including water, metal ions, and low molecular weight compounds such as glycerol used to make crystals",
+          "data": "https://integbio.jp/togosite/sparqlist/api/structure_other_related_molecules_pdb",
+          "type": "pdb",
+          "dataSource": {
+            "label": "",
+            "url": "",
+            "updateDate": ""
+          }
+        },
+        {
+          "id": "structure_analysis_methods_pdb",
+          "label": "Analysis methods",
+          "description": "Classification by the method used to determine the three-dimensional structure in Experimental method section from PDB",
+          "data": "https://integbio.jp/togosite/sparqlist/api/structure_analysis_methods_pdb",
+          "type": "pdb",
+          "dataSource": {
+            "label": "",
+            "url": "",
+            "updateDate": ""
+          }
+        },
+        {
+          "id": "structure_crystallization_temperature_pdb",
+          "label": "Crystallization temperature",
+          "description": "Temperature of the crystallization solution obtained in Crystallization Conditions section from PDB",
+          "data": "https://integbio.jp/togosite/sparqlist/api/structure_crystallization_temperature_pdb",
+          "type": "pdb",
+          "dataSource": {
+            "label": "",
+            "url": "",
+            "updateDate": ""
+          }
+        },
+        {
+          "id": "structure_crystallization_ph_pdb",
+          "label": "Crystallization pH",
+          "description": "pH value of the crystallization solution in Crystallization Conditions section from PDB",
+          "data": "https://integbio.jp/togosite/sparqlist/api/structure_crystallization_ph_pdb",
+          "type": "pdb",
+          "dataSource": {
+            "label": "",
+            "url": "",
+            "updateDate": ""
+          }
+        }
+      ]
+    },
+    {
+      "id": "interaction",
+      "label": "Interaction",
+      "attributes": [
+        {
+          "id": "interaction_proteins_in_pathway_reactome",
+          "label": "Proteins in pathway",
+          "description": "Proteins participating as components classified by pathway (reaction) from Reactome",
+          "data": "https://integbio.jp/togosite/sparqlist/api/interaction_proteins_in_pathway_reactome",
+          "type": "uniprot",
+          "dataSource": {
+            "label": "",
+            "url": "",
+            "updateDate": ""
+          }
+        },
+        {
+          "id": "interaction_compounds_in_pathway_reactome",
+          "label": "Compounds in pathway",
+          "description": "Compounds participating as components classified by pathway (reaction) from Reactome",
+          "data": "https://integbio.jp/togosite/sparqlist/api/interaction_compounds_in_pathway_reactome",
+          "type": "chebi",
+          "dataSource": {
+            "label": "",
+            "url": "",
+            "updateDate": ""
+          }
+        },
+        {
+          "id": "interaction_number_of_interacting_proteins_uniprot",
+          "label": "# of interacting proteins",
+          "description": "Classification of uniprot proteins by the number of target proteins they interact with in Interaction section from UniProt",
+          "data": "https://integbio.jp/togosite/sparqlist/api/interaction_number_of_interacting_proteins_uniprot",
+          "type": "uniprot",
+          "dataSource": {
+            "label": "",
+            "url": "",
+            "updateDate": ""
+          }
+        },
+        {
+          "id": "interaction_chembl_assay_existence_uniprot",
+          "label": "ChEMBL assay existence",
+          "description": "Uniprot entries classified according to the presence or absence of a method to detect direct protein-compound interactions (ChEMBL assay)",
+          "data": "https://integbio.jp/togosite/sparqlist/api/interaction_chembl_assay_existence_uniprot",
+          "type": "uniprot",
+          "dataSource": {
+            "label": "",
+            "url": "",
+            "updateDate": ""
+          }
+        }
+      ]
+    },
+    {
+      "id": "chemicalCompound",
+      "label": "Chemical compound",
+      "attributes": [
+        {
+          "id": "compound_substance_type_chembl",
+          "label": "Substance type",
+          "description": "Classification based on the type of drug, such as compound or nucleic acid drugs from ChEMBL",
+          "data": "https://integbio.jp/togosite/sparqlist/api/compound_substance_type_chembl",
+          "type": "chembl_compound",
+          "dataSource": {
+            "label": "",
+            "url": "",
+            "updateDate": ""
+          }
+        },
+        {
+          "id": "compound_chemical_role_chebi",
+          "label": "Chemical role",
+          "description": "Classification based on the chemical roles, such as antioxidant or environmental contaminant from ChEBI",
+          "data": "https://integbio.jp/togosite/sparqlist/api/compound_chemical_role_chebi",
+          "type": "chebi",
+          "dataSource": {
+            "label": "",
+            "url": "",
+            "updateDate": ""
+          }
+        },
+        {
+          "id": "compound_application_type_chebi",
+          "label": "Application type",
+          "description": "Classification based on the application types, such as pharmaceutical or pesticide from ChEBI",
+          "data": "https://integbio.jp/togosite/sparqlist/api/compound_application_type_chebi",
+          "type": "chebi",
+          "dataSource": {
+            "label": "",
+            "url": "",
+            "updateDate": ""
+          }
+        },
+        {
+          "id": "compound_action_type_chembl",
+          "label": "Action type",
+          "description": "Classification based on the mechanism of action, such as an inhibitor or an antagonist from ChEMBL",
+          "data": "https://integbio.jp/togosite/sparqlist/api/compound_action_type_chembl",
+          "type": "chembl_compound",
+          "dataSource": {
+            "label": "",
+            "url": "",
+            "updateDate": ""
+          }
+        },
+        {
+          "id": "compound_biological_role_chebi",
+          "label": "Biological role",
+          "description": "Classification based on the biological roles, such as inhibitor or antimicrobial agent from ChEBI",
+          "data": "https://integbio.jp/togosite/sparqlist/api/compound_biological_role_chebi",
+          "type": "chebi",
+          "dataSource": {
+            "label": "",
+            "url": "",
+            "updateDate": ""
+          }
+        },
+        {
+          "id": "compound_drug_indication_mesh_chembl",
+          "label": "Drug indication",
+          "description": "Classification of diseases for which drugs are indicated, based on hierarchical data using MeSH, a life science thesaurus from ChEMBL",
+          "data": "https://integbio.jp/togosite/sparqlist/api/compound_drug_indication_mesh_chembl",
+          "type": "chembl_compound",
+          "dataSource": {
+            "label": "",
+            "url": "",
+            "updateDate": ""
+          }
+        },
+        {
+          "id": "compound_drug_development_phase_chembl",
+          "label": "Drug development phase",
+          "description": "Classification based on the drug's development phase (research stage, phase I-III, and post-launch) from ChEMBL",
+          "data": "https://integbio.jp/togosite/sparqlist/api/compound_drug_development_phase_chembl",
+          "type": "chembl_compound",
+          "dataSource": {
+            "label": "",
+            "url": "",
+            "updateDate": ""
+          }
+        },
+        {
+          "id": "compound_atc_classification_pubchem",
+          "label": "PubChem ATC classification",
+          "description": "Classification of a medicine (in PubChem) according to its medicinal properties (WHO ATC Code)",
+          "data": "https://integbio.jp/togosite/sparqlist/api/compound_atc_classification_pubchem",
+          "type": "pubchem_compound",
+          "dataSource": {
+            "label": "",
+            "url": "",
+            "updateDate": ""
+          }
+        },
+        {
+          "id": "compound_atc_classification_chembl",
+          "label": "ChEMBL ATC classification",
+          "description": "Classification of a medicine (in ChEMBL) according to its medicinal properties (WHO ATC Code)",
+          "data": "https://integbio.jp/togosite/sparqlist/api/compound_atc_classification_chembl",
+          "type": "chembl_compound",
+          "dataSource": {
+            "label": "",
+            "url": "",
+            "updateDate": ""
+          }
+        }
+      ]
+    },
+    {
+      "id": "disease",
+      "label": "Disease",
+      "attributes": [
+        {
+          "id": "disease_diseases_mondo",
+          "label": "Diseases in Mondo",
+          "description": "Subcategories in the Disease or disorder category in the Mondo Disease Ontology (Mondo)",
+          "data": "https://integbio.jp/togosite/sparqlist/api/disease_diseases_mondo",
+          "type": "mondo",
+          "dataSource": {
+            "label": "",
+            "url": "",
+            "updateDate": ""
+          }
+        },
+        {
+          "id": "disease_diseases_mesh",
+          "label": "Diseases in MeSH",
+          "description": "Subcategories in the Disease category in Medical Subject Headings (MeSH)",
+          "data": "https://integbio.jp/togosite/sparqlist/api/disease_diseases_mesh",
+          "type": "mesh",
+          "dataSource": {
+            "label": "",
+            "url": "",
+            "updateDate": ""
+          }
+        },
+        {
+          "id": "disease_diseases_nando",
+          "label": "Diseases in NANDO",
+          "description": "Japanese rare and intractable disease categories in the Nanbyo Disease Ontology (NANDO)",
+          "data": "https://integbio.jp/togosite/sparqlist/api/disease_diseases_nando",
+          "type": "nando",
+          "dataSource": {
+            "label": "",
+            "url": "",
+            "updateDate": ""
+          }
+        },
+        {
+          "id": "disease_related_dbs_mondo",
+          "label": "Cross referenced disease DBs in Mondo",
+          "description": "Number of entries linked to Mondo in each of approx. 70 disease related databases from database cross reference in Mondo",
+          "data": "https://integbio.jp/togosite/sparqlist/api/disease_related_dbs_mondo",
+          "type": "mondo",
+          "dataSource": {
+            "label": "",
+            "url": "",
+            "updateDate": ""
+          }
+        },
+        {
+          "id": "disease_phenotypic_abnormality_hpo",
+          "label": "Phenotypic abnormality",
+          "description": "Classification the subcategories of the Phenotypic abnormality categories of the Human Phenotype Ontology (HPO)",
+          "data": "https://integbio.jp/togosite/sparqlist/api/disease_phenotypic_abnormality_hpo",
+          "type": "hp",
+          "dataSource": {
+            "label": "",
+            "url": "",
+            "updateDate": ""
+          }
+        }
+      ]
+    },
+    {
+      "id": "variant",
+      "label": "Variant",
+      "attributes": [
+        {
+          "id": "variant_gwas_togovar",
+          "label": "GWAS",
+          "description": "Classification of statistically significant variants in genome-wide association studies (GWAS) based on associated traits. Obtained from GWAS catalog via TogoVar",
+          "data": "https://integbio.jp/togosite/sparqlist/api/variant_gwas_togovar",
+          "type": "togovar",
+          "dataSource": {
+            "label": "",
+            "url": "",
+            "updateDate": ""
+          }
+        },
+        {
+          "id": "variant_clinical_significance_togovar",
+          "label": "Clinical significance",
+          "description": "Classification of variants according to their clinical significance, such as whether they are the cause of the disease or not. Obtained from ClinVar via TogoVar",
+          "data": "https://integbio.jp/togosite/sparqlist/api/variant_clinical_significance_togovar",
+          "type": "togovar",
+          "dataSource": {
+            "label": "",
+            "url": "",
+            "updateDate": ""
+          }
+        }
+      ]
+    }
+  ],
+  "identifiers": {
+    "ensembl_gene": {
+      "label": "Ensembl gene",
+      "template": "https://raw.githubusercontent.com/dbcls/togosite/develop/config/togosite-human/templates/ensembl_gene.hbs",
+      "target": true
+    },
+    "ensembl_transcript": {
+      "label": "Ensembl transcript",
+      "template": "https://raw.githubusercontent.com/dbcls/togosite/develop/config/togosite-human/templates/ensembl_transcript.hbs",
+      "target": true
+    },
+    "ncbigene": {
+      "label": "NCBI gene",
+      "template": "https://raw.githubusercontent.com/dbcls/togosite/develop/config/togosite-human/templates/ncbigene.hbs",
+      "target": true
+    },
+    "uniprot": {
+      "label": "UniProt",
+      "template": "https://raw.githubusercontent.com/dbcls/togosite/develop/config/togosite-human/templates/uniprot.hbs",
+      "target": true
+    },
+    "pdb": {
+      "label": "PDB",
+      "template": "https://raw.githubusercontent.com/dbcls/togosite/develop/config/togosite-human/templates/pdb.hbs",
+      "target": true
+    },
+    "chebi": {
+      "label": "ChEBI compound",
+      "template": "https://raw.githubusercontent.com/dbcls/togosite/develop/config/togosite-human/templates/chebi.hbs",
+      "target": true
+    },
+    "chembl_compound": {
+      "label": "ChEMBL compound",
+      "template": "https://raw.githubusercontent.com/dbcls/togosite/develop/config/togosite-human/templates/chembl_compound.hbs",
+      "target": true
+    },
+    "pubchem_compound": {
+      "label": "PubChem compound",
+      "template": "https://raw.githubusercontent.com/dbcls/togosite/develop/config/togosite-human/templates/pubchem_compound.hbs",
+      "target": true
+    },
+    "mondo": {
+      "label": "Mondo",
+      "template": "https://raw.githubusercontent.com/dbcls/togosite/develop/config/togosite-human/templates/mondo.hbs",
+      "target": true
+    },
+    "mesh": {
+      "label": "MeSH",
+      "template": "https://raw.githubusercontent.com/dbcls/togosite/develop/config/togosite-human/templates/mesh.hbs",
+      "target": true
+    },
+    "nando": {
+      "label": "NANDO",
+      "template": "https://raw.githubusercontent.com/dbcls/togosite/develop/config/togosite-human/templates/nando.hbs",
+      "target": true
+    },
+    "hp": {
+      "label": "Human Phenotype Ontology",
+      "template": "https://raw.githubusercontent.com/dbcls/togosite/develop/config/togosite-human/templates/hp.hbs",
+      "target": true
+    },
+    "togovar": {
+      "label": "TogoVar variant",
+      "template": "https://raw.githubusercontent.com/dbcls/togosite/develop/config/togosite-human/templates/togovar.hbs",
+      "target": true
+    }
+  }
+}

--- a/config/togosite-human/attributes.json
+++ b/config/togosite-human/attributes.json
@@ -13,6 +13,8 @@
         "gene_low_level_expression_refex",
         "gene_high_level_expression_gtex6",
         "gene_not_expressed_in_tissue_gtex",
+        "gene_specific_expression_in_tissues_hpa",
+        "gene_specific_expression_in_cells_hpa",
         "gene_transcription_factors_chip_atlas"
       ]
     },
@@ -32,6 +34,10 @@
         "protein_number_of_glycosylation_sites_uniprot",
         "protein_disease_related_proteins_uniprot",
         "protein_isolation_source_uniprot",
+        "protein_high_level_expression_in_tissues_hpa",
+        "protein_medium_level_expression_in_tissues_hpa",
+        "protein_low_level_expression_in_tissues_hpa",
+        "protein_no_expression_in_tissues_hpa",
         "protein_evidence_of_existence_nextprot"
       ]
     },
@@ -98,563 +104,800 @@
     "gene_biotype_ensembl": {
       "label": "Gene biotype",
       "description": "Gene or transcript classification annotated in Ensembl",
-      "data": "https://integbio.jp/togosite/sparqlist/api/gene_biotype_ensembl",
+      "api": "https://integbio.jp/togosite/sparqlist/api/gene_biotype_ensembl",
       "idType": "ensembl_gene",
-      "dataSource": {
-        "label": "Ensembl",
-        "url": "http://nov2020.archive.ensembl.org/Homo_sapiens/Info/Index",
-        "updateDate": "14 Jul, 2021"
-      }
+      "data": [
+        {
+          "label": "Ensembl",
+          "url": "http://nov2020.archive.ensembl.org/Homo_sapiens/Info/Index",
+          "version": null,
+          "updateDate": "14 Jul, 2021"
+        }
+      ]
     },
     "gene_chromosome_ensembl": {
       "label": "Chromosome",
       "description": "Chromosome where a gene is located",
-      "data": "https://integbio.jp/togosite/sparqlist/api/gene_chromosome_ensembl",
+      "api": "https://integbio.jp/togosite/sparqlist/api/gene_chromosome_ensembl",
       "idType": "ensembl_gene",
-      "dataSource": {
-        "label": "Ensembl human release 102",
-        "url": "http://nov2020.archive.ensembl.org/Homo_sapiens/Info/Index",
-        "updateDate": "14 Jul, 2021"
-      }
+      "data": [
+        {
+          "label": "Ensembl human release 102",
+          "url": "http://nov2020.archive.ensembl.org/Homo_sapiens/Info/Index",
+          "version": null,
+          "updateDate": "14 Jul, 2021"
+        }
+      ]
     },
     "gene_number_of_exons_ensembl": {
       "label": "# of exons",
       "description": "Number of exons for each transcript of each gene",
-      "data": "https://integbio.jp/togosite/sparqlist/api/gene_number_of_exons_ensembl",
+      "api": "https://integbio.jp/togosite/sparqlist/api/gene_number_of_exons_ensembl",
       "idType": "ensembl_transcript",
-      "dataSource": {
-        "label": "Ensembl human release 102",
-        "url": "http://nov2020.archive.ensembl.org/Homo_sapiens/Info/Index",
-        "updateDate": "14 Jul, 2021"
-      }
+      "data": [
+        {
+          "label": "Ensembl human release 102",
+          "url": "http://nov2020.archive.ensembl.org/Homo_sapiens/Info/Index",
+          "version": null,
+          "updateDate": "14 Jul, 2021"
+        }
+      ]
     },
     "gene_number_of_paralogs_homologene": {
       "label": "# of paralogs",
       "description": "Number of duplicated genes (paralogs) in each human gene calculated based on HomoloGene",
-      "data": "https://integbio.jp/togosite/sparqlist/api/gene_number_of_paralogs_homologene",
+      "api": "https://integbio.jp/togosite/sparqlist/api/gene_number_of_paralogs_homologene",
       "idType": "ncbigene",
-      "dataSource": {
-        "label": "HomoloGene",
-        "url": "https://www.ncbi.nlm.nih.gov/homologene/statistics/",
-        "updateDate": "14 Jul, 2021"
-      }
+      "data": [
+        {
+          "label": "HomoloGene",
+          "url": "https://www.ncbi.nlm.nih.gov/homologene/statistics/",
+          "version": null,
+          "updateDate": "14 Jul, 2021"
+        }
+      ]
     },
     "gene_evolutionary_conservation_homologene": {
       "label": "Evolutionary divergence",
       "description": "Most distant organisms from human that have orthologous genes in HomoloGene",
-      "data": "https://integbio.jp/togosite/sparqlist/api/gene_evolutionary_conservation_homologene",
+      "api": "https://integbio.jp/togosite/sparqlist/api/gene_evolutionary_conservation_homologene",
       "idType": "ncbigene",
-      "dataSource": {
-        "label": "HomoloGene",
-        "url": "https://www.ncbi.nlm.nih.gov/homologene/statistics/",
-        "updateDate": "14 Jul, 2021"
-      }
+      "data": [
+        {
+          "label": "HomoloGene",
+          "url": "https://www.ncbi.nlm.nih.gov/homologene/statistics/",
+          "version": null,
+          "updateDate": "14 Jul, 2021"
+        }
+      ]
     },
     "gene_high_level_expression_refex": {
       "label": "High-level expression",
       "description": "Tissues in which a gene was tissue-specific highly expressed only in one of 34 tissues of RefEx",
-      "data": "https://integbio.jp/togosite/sparqlist/api/gene_high_level_expression_refex",
+      "api": "https://integbio.jp/togosite/sparqlist/api/gene_high_level_expression_refex",
       "idType": "ncbigene",
-      "dataSource": {
-        "label": "Calculations for tissue specificity of genechip human GSE7307 from RefEx",
-        "url": "https://doi.org/10.6084/m9.figshare.4028700.v3",
-        "updateDate": "14 Jul, 2021"
-      }
+      "data": [
+        {
+          "label": "Calculations for tissue specificity of genechip human GSE7307 from RefEx",
+          "url": "https://doi.org/10.6084/m9.figshare.4028700.v3",
+          "version": null,
+          "updateDate": "14 Jul, 2021"
+        }
+      ]
     },
     "gene_low_level_expression_refex": {
       "label": "Low-level expression",
       "description": "Tissues in which a gene was tissue-specific lowly expressed only in one of 34 tissues of RefEx",
-      "data": "https://integbio.jp/togosite/sparqlist/api/gene_low_level_expression_refex",
+      "api": "https://integbio.jp/togosite/sparqlist/api/gene_low_level_expression_refex",
       "idType": "ncbigene",
-      "dataSource": {
-        "label": "Calculations for tissue specificity of genechip human GSE7307 from RefEx",
-        "url": "https://doi.org/10.6084/m9.figshare.4028700.v3",
-        "updateDate": "14 Jul, 2021"
-      }
+      "data": [
+        {
+          "label": "Calculations for tissue specificity of genechip human GSE7307 from RefEx",
+          "url": "https://doi.org/10.6084/m9.figshare.4028700.v3",
+          "version": null,
+          "updateDate": "14 Jul, 2021"
+        }
+      ]
     },
     "gene_high_level_expression_gtex6": {
       "label": "Expressed in tissues",
       "description": "Tissues in which a gene is tissue-specific highly expressed in 48 tissues of GTEx",
-      "data": "https://integbio.jp/togosite/sparqlist/api/gene_high_level_expression_gtex6",
+      "api": "https://integbio.jp/togosite/sparqlist/api/gene_high_level_expression_gtex6",
       "idType": "ensembl_gene",
-      "dataSource": {
-        "label": "Supplementary Table 1 of A systematic survey of human tissue-specific gene expression and splicing reveals new opportunities for therapeutic target identification and evaluation; R. Y. Yang et al.; bioRxiv 311563",
-        "url": "https://doi.org/10.1101/311563",
-        "updateDate": "14 Jul, 2021"
-      }
+      "data": [
+        {
+          "label": "Supplementary Table 1 of A systematic survey of human tissue-specific gene expression and splicing reveals new opportunities for therapeutic target identification and evaluation; R. Y. Yang et al.; bioRxiv 311563",
+          "url": "https://doi.org/10.1101/311563",
+          "version": null,
+          "updateDate": "14 Jul, 2021"
+        }
+      ]
     },
     "gene_not_expressed_in_tissue_gtex": {
       "label": "Not expressed in tissues",
       "description": "Tissues in which expression of a gene is not detected in 48 tissues of GTEx",
-      "data": "https://integbio.jp/togosite/sparqlist/api/gene_not_expressed_in_tissues_gtex",
+      "api": "https://integbio.jp/togosite/sparqlist/api/gene_not_expressed_in_tissues_gtex",
       "idType": "ensembl_gene",
-      "dataSource": {
-        "label": "Supplementary Table 1 of A systematic survey of human tissue-specific gene expression and splicing reveals new opportunities for therapeutic target identification and evaluation; R. Y. Yang et al.; bioRxiv 311563",
-        "url": "https://doi.org/10.1101/311563",
-        "updateDate": "14 Jul, 2021"
-      }
+      "data": [
+        {
+          "label": "Supplementary Table 1 of A systematic survey of human tissue-specific gene expression and splicing reveals new opportunities for therapeutic target identification and evaluation; R. Y. Yang et al.; bioRxiv 311563",
+          "url": "https://doi.org/10.1101/311563",
+          "version": null,
+          "updateDate": "14 Jul, 2021"
+        }
+      ]
+    },
+    "gene_specific_expression_in_tissues_hpa": {
+      "label": "Specifically expressed in tissues (HPA)",
+      "description": "Tissues in which expression specificity of a gene is evaluated as \"Tissue enriched\", \"Tissue enhanced\", or\"Group enriched\" by HPA",
+      "api": "https://integbio.jp/togosite/sparqlist/api/gene_specific_expression_in_tissues_hpa",
+      "idType": "ensembl_gene",
+      "data": [
+        {
+          "label": "HPA TSV",
+          "url": "https://www.proteinatlas.org/about/download",
+          "version": null,
+          "updateDate": "28 Jul, 2021"
+        }
+      ]
+    },
+    "gene_specific_expression_in_cells_hpa": {
+      "label": "Specifically expressed in cell types (HPA)",
+      "description": "Cell types in which expression specificity of a gene is evaluated as \"Cell type enriched\", \"Cell type enhanced\", or\"Group enriched\" by HPA",
+      "api": "https://integbio.jp/togosite/sparqlist/api/gene_specific_expression_in_cells_hpa",
+      "idType": "ensembl_gene",
+      "data": [
+        {
+          "label": "HPA TSV",
+          "url": "https://www.proteinatlas.org/about/download",
+          "version": null,
+          "updateDate": "28 Jul, 2021"
+        }
+      ]
     },
     "gene_transcription_factors_chip_atlas": {
       "label": "Transcription factors",
       "description": "Transcription factors with predicted target genes in ChIP-Atlas",
-      "data": "https://integbio.jp/togosite/sparqlist/api/gene_transcription_factors_chip_atlas",
+      "api": "https://integbio.jp/togosite/sparqlist/api/gene_transcription_factors_chip_atlas",
       "idType": "ensembl_gene",
-      "dataSource": {
-        "label": "ChIP-Atlas",
-        "url": "http://dbarchive.biosciencedbc.jp/kyushu-u/hg38/target/",
-        "updateDate": "14 Jul, 2021"
-      }
+      "data": [
+        {
+          "label": "ChIP-Atlas",
+          "url": "http://dbarchive.biosciencedbc.jp/kyushu-u/hg38/target/",
+          "version": null,
+          "updateDate": "14 Jul, 2021"
+        }
+      ]
     },
     "protein_domains_uniprot": {
       "label": "Protein domains",
       "description": "Protein domains from UniProt",
-      "data": "https://integbio.jp/togosite/sparqlist/api/protein_domains_uniprot",
+      "api": "https://integbio.jp/togosite/sparqlist/api/protein_domains_uniprot",
       "idType": "uniprot",
-      "dataSource": {
-        "label": "",
-        "url": "",
-        "updateDate": ""
-      }
+      "data": [
+        {
+          "label": "UniProt",
+          "url": "https://www.uniprot.org/",
+          "version": null,
+          "updateDate": "14 Jul, 2021"
+        }
+      ]
     },
     "protein_cellular_component_uniprot": {
       "label": "Cellular component",
       "description": "Functional annotations (GO terms) derived from the Cellular component category of GeneOntology, which Uniprot has assigned to each human protein with evidence information",
-      "data": "https://integbio.jp/togosite/sparqlist/api/protein_cellular_component_uniprot",
+      "api": "https://integbio.jp/togosite/sparqlist/api/protein_cellular_component_uniprot",
       "idType": "uniprot",
-      "dataSource": {
-        "label": "",
-        "url": "",
-        "updateDate": ""
-      }
+      "data": [
+        {
+          "label": "Gene ontology cellular component annotation from UniProt",
+          "url": "https://www.uniprot.org/",
+          "version": null,
+          "updateDate": "14 Jul, 2021"
+        }
+      ]
     },
     "protein_biological_process_uniprot": {
       "label": "Biological process",
       "description": "Functional annotations (GO terms) derived from the Biological process category of GeneOntology, which Uniprot has assigned to each human protein with evidence information",
-      "data": "https://integbio.jp/togosite/sparqlist/api/protein_biological_process_uniprot",
+      "api": "https://integbio.jp/togosite/sparqlist/api/protein_biological_process_uniprot",
       "idType": "uniprot",
-      "dataSource": {
-        "label": "",
-        "url": "",
-        "updateDate": ""
-      }
+      "data": [
+        {
+          "label": "Gene ontology biological process annotation from UniProt",
+          "url": "https://www.uniprot.org/",
+          "version": null,
+          "updateDate": "14 Jul, 2021"
+        }
+      ]
     },
     "protein_molecular_function_uniprot": {
       "label": "Molecular function",
       "description": "Functional annotations (GO terms) derived from the Molecular function category of GeneOntology, which Uniprot has assigned to each human protein with evidence information",
-      "data": "https://integbio.jp/togosite/sparqlist/api/protein_molecular_function_uniprot",
+      "api": "https://integbio.jp/togosite/sparqlist/api/protein_molecular_function_uniprot",
       "idType": "uniprot",
-      "dataSource": {
-        "label": "",
-        "url": "",
-        "updateDate": ""
-      }
+      "data": [
+        {
+          "label": "Gene ontology molecular function annotation from UniProt",
+          "url": "https://www.uniprot.org/",
+          "version": null,
+          "updateDate": "14 Jul, 2021"
+        }
+      ]
     },
     "protein_ligands_uniprot": {
       "label": "Ligands",
       "description": "Classification by non-protein molecules which bind/react with proteins in Function section from UniProt",
-      "data": "https://integbio.jp/togosite/sparqlist/api/protein_ligands_uniprot",
+      "api": "https://integbio.jp/togosite/sparqlist/api/protein_ligands_uniprot",
       "idType": "uniprot",
-      "dataSource": {
-        "label": "",
-        "url": "",
-        "updateDate": ""
-      }
+      "data": [
+        {
+          "label": "Function from UniProt",
+          "url": "https://www.uniprot.org/",
+          "version": null,
+          "updateDate": "14 Jul, 2021"
+        }
+      ]
     },
     "protein_molecular_mass_uniprot": {
       "label": "Molecular mass",
       "description": "Molecular weight of the protein including information from multiple isoforms in Sequences section from UniProt",
-      "data": "https://integbio.jp/togosite/sparqlist/api/protein_molecular_mass_uniprot",
+      "api": "https://integbio.jp/togosite/sparqlist/api/protein_molecular_mass_uniprot",
       "idType": "uniprot",
-      "dataSource": {
-        "label": "",
-        "url": "",
-        "updateDate": ""
-      }
+      "data": [
+        {
+          "label": "Sequences from UniProt",
+          "url": "https://www.uniprot.org/",
+          "version": null,
+          "updateDate": "14 Jul, 2021"
+        }
+      ]
     },
     "protein_ptms_uniprot": {
       "label": "PTMs",
       "description": "Classification by types of post-translational modifications, including S-S bonds (disulfide bonds) in Amino acid modifications section from UniProt",
-      "data": "https://integbio.jp/togosite/sparqlist/api/protein_ptms_uniprot",
+      "api": "https://integbio.jp/togosite/sparqlist/api/protein_ptms_uniprot",
       "idType": "uniprot",
-      "dataSource": {
-        "label": "",
-        "url": "",
-        "updateDate": ""
-      }
+      "data": [
+        {
+          "label": "Amino acid modifications from UniProt",
+          "url": "https://www.uniprot.org/",
+          "version": null,
+          "updateDate": "14 Jul, 2021"
+        }
+      ]
     },
     "protein_number_of_transmembrane_domains_uniprot": {
       "label": "# of transmembrane domains",
       "description": "Number of transmembrane domains. A group of molecules forming a family, such as channels, may have the same number of domains in Topology section from UniProt",
-      "data": "https://integbio.jp/togosite/sparqlist/api/protein_number_of_transmembrane_domains_uniprot",
+      "api": "https://integbio.jp/togosite/sparqlist/api/protein_number_of_transmembrane_domains_uniprot",
       "idType": "uniprot",
-      "dataSource": {
-        "label": "",
-        "url": "",
-        "updateDate": ""
-      }
+      "data": [
+        {
+          "label": "Topology from UniProt",
+          "url": "https://www.uniprot.org/",
+          "version": null,
+          "updateDate": "14 Jul, 2021"
+        }
+      ]
     },
     "protein_number_of_phosphorylation_sites_uniprot": {
       "label": "# of phosphorylation sites",
       "description": "Number of phosphorylation at Ser/Thr/Tyr, which may create an activation state for the protein and acts like a switch in Amino acid modifications section from UniProt",
-      "data": "https://integbio.jp/togosite/sparqlist/api/protein_number_of_phosphorylation_sites_uniprot",
+      "api": "https://integbio.jp/togosite/sparqlist/api/protein_number_of_phosphorylation_sites_uniprot",
       "idType": "uniprot",
-      "dataSource": {
-        "label": "",
-        "url": "",
-        "updateDate": ""
-      }
+      "data": [
+        {
+          "label": "Amino acid modifications from UniProt",
+          "url": "https://www.uniprot.org/",
+          "version": null,
+          "updateDate": "14 Jul, 2021"
+        }
+      ]
     },
     "protein_number_of_glycosylation_sites_uniprot": {
       "label": "# of glycosylation sites",
       "description": "Number of glycosylation sites, including N-linked,O-linked and others in Amino acid modifications section from UniProt",
-      "data": "https://integbio.jp/togosite/sparqlist/api/protein_number_of_glycosylation_sites_uniprot",
+      "api": "https://integbio.jp/togosite/sparqlist/api/protein_number_of_glycosylation_sites_uniprot",
       "idType": "uniprot",
-      "dataSource": {
-        "label": "",
-        "url": "",
-        "updateDate": ""
-      }
+      "data": [
+        {
+          "label": "Amino acid modifications from UniProt",
+          "url": "https://www.uniprot.org/",
+          "version": null,
+          "updateDate": "14 Jul, 2021"
+        }
+      ]
     },
     "protein_disease_related_proteins_uniprot": {
       "label": "Disease-related proteins",
       "description": "Disease-related proteins in Pathology & Biotech section from UniProt",
-      "data": "https://integbio.jp/togosite/sparqlist/api/protein_disease_related_proteins_uniprot",
+      "api": "https://integbio.jp/togosite/sparqlist/api/protein_disease_related_proteins_uniprot",
       "idType": "uniprot",
-      "dataSource": {
-        "label": "",
-        "url": "",
-        "updateDate": ""
-      }
+      "data": [
+        {
+          "label": "Pathology & Biotech from UniProt",
+          "url": "https://www.uniprot.org/",
+          "version": null,
+          "updateDate": "14 Jul, 2021"
+        }
+      ]
     },
     "protein_isolation_source_uniprot": {
       "label": "Tissues w/expression reported",
       "description": "Classification based on the name of the tissue from which the clone was isolated in the reference describing the protein sequence in Tissue section from UniProt",
-      "data": "https://integbio.jp/togosite/sparqlist/api/protein_isolation_source_uniprot",
+      "api": "https://integbio.jp/togosite/sparqlist/api/protein_isolation_source_uniprot",
       "idType": "uniprot",
-      "dataSource": {
-        "label": "",
-        "url": "",
-        "updateDate": ""
-      }
+      "data": [
+        {
+          "label": "Tissue from UniProt",
+          "url": "https://www.uniprot.org/",
+          "version": null,
+          "updateDate": "14 Jul, 2021"
+        }
+      ]
+    },
+    "protein_high_level_expression_in_tissues_hpa": {
+      "label": "Highly expressed in tissues (HPA)",
+      "description": "Tissues in which expression level of a gene is evaluated as \"High\" by HPA",
+      "api": "https://integbio.jp/togosite/sparqlist/api/protein_high_level_expression_in_tissues_hpa",
+      "idType": "ensembl_gene",
+      "data": [
+        {
+          "label": "HPA RDF",
+          "url": "https://www.proteinatlas.org/about/download",
+          "version": null,
+          "updateDate": "28 Jul, 2021"
+        }
+      ]
+    },
+    "protein_medium_level_expression_in_tissues_hpa": {
+      "label": "Intermediately expressed in tissues (HPA)",
+      "description": "Tissues in which expression level of a gene is evaluated as \"Medium\" by HPA",
+      "api": "https://integbio.jp/togosite/sparqlist/api/protein_medium_level_expression_in_tissues_hpa",
+      "idType": "ensembl_gene",
+      "data": [
+        {
+          "label": "HPA RDF",
+          "url": "https://www.proteinatlas.org/about/download",
+          "version": null,
+          "updateDate": "28 Jul, 2021"
+        }
+      ]
+    },
+    "protein_low_level_expression_in_tissues_hpa": {
+      "label": "Lowly expressed in tissues (HPA)",
+      "description": "Tissues in which expression level of a gene is evaluated as \"Low\" by HPA",
+      "api": "https://integbio.jp/togosite/sparqlist/api/protein_low_level_expression_in_tissues_hpa",
+      "idType": "ensembl_gene",
+      "data": [
+        {
+          "label": "HPA RDF",
+          "url": "https://www.proteinatlas.org/about/download",
+          "version": null,
+          "updateDate": "28 Jul, 2021"
+        }
+      ]
+    },
+    "protein_no_expression_in_tissues_hpa": {
+      "label": "Not expressed in tissues (HPA)",
+      "description": "Tissues in which expression level of a gene is evaluated as \"Not_detected\" by HPA",
+      "api": "https://integbio.jp/togosite/sparqlist/api/protein_no_expression_in_tissues_hpa",
+      "idType": "ensembl_gene",
+      "data": [
+        {
+          "label": "HPA RDF",
+          "url": "https://www.proteinatlas.org/about/download",
+          "version": null,
+          "updateDate": "28 Jul, 2021"
+        }
+      ]
     },
     "protein_evidence_of_existence_nextprot": {
       "label": "Evidence of existence",
       "description": "Classification by the basis of protein expression, such as whether it has been identified as a protein or transcript in Expression section from neXtProt",
-      "data": "https://integbio.jp/togosite/sparqlist/api/protein_evidence_of_existence_nextprot",
+      "api": "https://integbio.jp/togosite/sparqlist/api/protein_evidence_of_existence_nextprot",
       "idType": "uniprot",
-      "dataSource": {
-        "label": "",
-        "url": "",
-        "updateDate": ""
-      }
+      "data": [
+        {
+          "label": "Expression from neXtProt",
+          "url": "https://www.nextprot.org/",
+          "version": null,
+          "updateDate": "14 Jul, 2021"
+        }
+      ]
     },
     "structure_data_existence_uniprot": {
       "label": "Structure data existence",
       "description": "Uniprot entries having 3D structure data in PDB in Structure section from Uniprot",
-      "data": "https://integbio.jp/togosite/sparqlist/api/structure_data_existence_uniprot",
+      "api": "https://integbio.jp/togosite/sparqlist/api/structure_data_existence_uniprot",
       "idType": "uniprot",
-      "dataSource": {
-        "label": "",
-        "url": "",
-        "updateDate": ""
-      }
+      "data": [
+        {
+          "label": "Structure from Uniprot",
+          "url": "https://www.uniprot.org/help/structure_section",
+          "version": null,
+          "updateDate": "14 Jul, 2021"
+        }
+      ]
     },
     "structure_number_of_alpha_helices_pdb": {
       "label": "# of alpha-helices",
       "description": "Number of 'Helix' entities counted in each entry of PDB",
-      "data": "https://integbio.jp/togosite/sparqlist/api/structure_number_of_alpha_helices_pdb",
+      "api": "https://integbio.jp/togosite/sparqlist/api/structure_number_of_alpha_helices_pdb",
       "idType": "pdb",
-      "dataSource": {
-        "label": "",
-        "url": "",
-        "updateDate": ""
-      }
+      "data": [
+        {
+          "label": "'Helix' entities counted in each entry of PDB",
+          "url": "https://data.pdbj.org/pdbjplus/data/pdb/rdf/",
+          "version": null,
+          "updateDate": "14 Jul, 2021"
+        }
+      ]
     },
     "structure_number_of_beta_sheets_pdb": {
       "label": "# of beta-sheets",
       "description": "Number of 'Sheet' entities counted in each entry of PDB",
-      "data": "https://integbio.jp/togosite/sparqlist/api/structure_number_of_beta_sheets_pdb",
+      "api": "https://integbio.jp/togosite/sparqlist/api/structure_number_of_beta_sheets_pdb",
       "idType": "pdb",
-      "dataSource": {
-        "label": "",
-        "url": "",
-        "updateDate": ""
-      }
+      "data": [
+        {
+          "label": "'Sheet' entities counted in each entry of PDB",
+          "url": "https://data.pdbj.org/pdbjplus/data/pdb/rdf/",
+          "version": null,
+          "updateDate": "14 Jul, 2021"
+        }
+      ]
     },
     "structure_number_of_peptides_pdb": {
       "label": "# of peptides in a PDB entry",
       "description": "The number of peptides in a PDB entry",
-      "data": "https://integbio.jp/togosite/sparqlist/api/structure_number_of_peptides_pdb",
+      "api": "https://integbio.jp/togosite/sparqlist/api/structure_number_of_peptides_pdb",
       "idType": "pdb",
-      "dataSource": {
-        "label": "",
-        "url": "",
-        "updateDate": ""
-      }
+      "data": [
+        {
+          "label": "Entity from PDB",
+          "url": "https://data.pdbj.org/pdbjplus/data/pdb/rdf/",
+          "version": null,
+          "updateDate": "14 Jul, 2021"
+        }
+      ]
     },
     "structure_other_related_molecules_pdb": {
       "label": "Other related molecules",
       "description": "Nonpeptide molecules related protein structures including water, metal ions, and low molecular weight compounds such as glycerol used to make crystals",
-      "data": "https://integbio.jp/togosite/sparqlist/api/structure_other_related_molecules_pdb",
+      "api": "https://integbio.jp/togosite/sparqlist/api/structure_other_related_molecules_pdb",
       "idType": "pdb",
-      "dataSource": {
-        "label": "",
-        "url": "",
-        "updateDate": ""
-      }
+      "data": [
+        {
+          "label": "Entity from PDB",
+          "url": "https://data.pdbj.org/pdbjplus/data/pdb/rdf/",
+          "version": null,
+          "updateDate": "14 Jul, 2021"
+        }
+      ]
     },
     "structure_analysis_methods_pdb": {
       "label": "Analysis methods",
       "description": "Classification by the method used to determine the three-dimensional structure in Experimental method section from PDB",
-      "data": "https://integbio.jp/togosite/sparqlist/api/structure_analysis_methods_pdb",
+      "api": "https://integbio.jp/togosite/sparqlist/api/structure_analysis_methods_pdb",
       "idType": "pdb",
-      "dataSource": {
-        "label": "",
-        "url": "",
-        "updateDate": ""
-      }
+      "data": [
+        {
+          "label": "Experimental method from PDB",
+          "url": "https://data.pdbj.org/pdbjplus/data/pdb/rdf/",
+          "version": null,
+          "updateDate": "14 Jul, 2021"
+        }
+      ]
     },
     "structure_crystallization_temperature_pdb": {
       "label": "Crystallization temperature",
       "description": "Temperature of the crystallization solution obtained in Crystallization Conditions section from PDB",
-      "data": "https://integbio.jp/togosite/sparqlist/api/structure_crystallization_temperature_pdb",
+      "api": "https://integbio.jp/togosite/sparqlist/api/structure_crystallization_temperature_pdb",
       "idType": "pdb",
-      "dataSource": {
-        "label": "",
-        "url": "",
-        "updateDate": ""
-      }
+      "data": [
+        {
+          "label": "Crystallization Conditions from PDB",
+          "url": "https://data.pdbj.org/pdbjplus/data/pdb/rdf/",
+          "version": null,
+          "updateDate": "14 Jul, 2021"
+        }
+      ]
     },
     "structure_crystallization_ph_pdb": {
       "label": "Crystallization pH",
       "description": "pH value of the crystallization solution in Crystallization Conditions section from PDB",
-      "data": "https://integbio.jp/togosite/sparqlist/api/structure_crystallization_ph_pdb",
+      "api": "https://integbio.jp/togosite/sparqlist/api/structure_crystallization_ph_pdb",
       "idType": "pdb",
-      "dataSource": {
-        "label": "",
-        "url": "",
-        "updateDate": ""
-      }
+      "data": [
+        {
+          "label": "Crystallization Conditions from PDB",
+          "url": "https://data.pdbj.org/pdbjplus/data/pdb/rdf/",
+          "version": null,
+          "updateDate": "14 Jul, 2021"
+        }
+      ]
     },
     "interaction_proteins_in_pathway_reactome": {
       "label": "Proteins in pathway",
       "description": "Proteins participating as components classified by pathway (reaction) from Reactome",
-      "data": "https://integbio.jp/togosite/sparqlist/api/interaction_proteins_in_pathway_reactome",
+      "api": "https://integbio.jp/togosite/sparqlist/api/interaction_proteins_in_pathway_reactome",
       "idType": "uniprot",
-      "dataSource": {
-        "label": "",
-        "url": "",
-        "updateDate": ""
-      }
+      "data": [
+        {
+          "label": "Reactome",
+          "url": "https://reactome.org/download-data",
+          "version": null,
+          "updateDate": "14 Jul, 2021"
+        }
+      ]
     },
     "interaction_compounds_in_pathway_reactome": {
       "label": "Compounds in pathway",
       "description": "Compounds participating as components classified by pathway (reaction) from Reactome",
-      "data": "https://integbio.jp/togosite/sparqlist/api/interaction_compounds_in_pathway_reactome",
+      "api": "https://integbio.jp/togosite/sparqlist/api/interaction_compounds_in_pathway_reactome",
       "idType": "chebi",
-      "dataSource": {
-        "label": "",
-        "url": "",
-        "updateDate": ""
-      }
+      "data": [
+        {
+          "label": "Reactome",
+          "url": "https://reactome.org/download-data",
+          "version": null,
+          "updateDate": "14 Jul, 2021"
+        }
+      ]
     },
     "interaction_number_of_interacting_proteins_uniprot": {
       "label": "# of interacting proteins",
       "description": "Classification of uniprot proteins by the number of target proteins they interact with in Interaction section from UniProt",
-      "data": "https://integbio.jp/togosite/sparqlist/api/interaction_number_of_interacting_proteins_uniprot",
+      "api": "https://integbio.jp/togosite/sparqlist/api/interaction_number_of_interacting_proteins_uniprot",
       "idType": "uniprot",
-      "dataSource": {
-        "label": "",
-        "url": "",
-        "updateDate": ""
-      }
+      "data": [
+        {
+          "label": "Interaction from UniProt",
+          "url": "https://www.uniprot.org/help/interaction_section",
+          "version": null,
+          "updateDate": "14 Jul, 2021"
+        }
+      ]
     },
     "interaction_chembl_assay_existence_uniprot": {
       "label": "ChEMBL assay existence",
       "description": "Uniprot entries classified according to the presence or absence of a method to detect direct protein-compound interactions (ChEMBL assay)",
-      "data": "https://integbio.jp/togosite/sparqlist/api/interaction_chembl_assay_existence_uniprot",
+      "api": "https://integbio.jp/togosite/sparqlist/api/interaction_chembl_assay_existence_uniprot",
       "idType": "uniprot",
-      "dataSource": {
-        "label": "",
-        "url": "",
-        "updateDate": ""
-      }
+      "data": [
+        {
+          "label": "Target protein from ChEMBL-RDF 28.0 against all UniProt entries",
+          "url": "http://ftp.ebi.ac.uk/pub/databases/chembl/ChEMBL-RDF/",
+          "version": null,
+          "updateDate": "14 Jul, 2021"
+        }
+      ]
     },
     "compound_substance_type_chembl": {
       "label": "Substance type",
       "description": "Classification based on the type of drug, such as compound or nucleic acid drugs from ChEMBL",
-      "data": "https://integbio.jp/togosite/sparqlist/api/compound_substance_type_chembl",
+      "api": "https://integbio.jp/togosite/sparqlist/api/compound_substance_type_chembl",
       "idType": "chembl_compound",
-      "dataSource": {
-        "label": "",
-        "url": "",
-        "updateDate": ""
-      }
+      "data": [
+        {
+          "label": "ChEMBL-RDF",
+          "url": "http://ftp.ebi.ac.uk/pub/databases/chembl/ChEMBL-RDF/",
+          "version": null,
+          "updateDate": "14 Jul, 2021"
+        }
+      ]
     },
     "compound_chemical_role_chebi": {
       "label": "Chemical role",
       "description": "Classification based on the chemical roles, such as antioxidant or environmental contaminant from ChEBI",
-      "data": "https://integbio.jp/togosite/sparqlist/api/compound_chemical_role_chebi",
+      "api": "https://integbio.jp/togosite/sparqlist/api/compound_chemical_role_chebi",
       "idType": "chebi",
-      "dataSource": {
-        "label": "",
-        "url": "",
-        "updateDate": ""
-      }
+      "data": [
+        {
+          "label": "",
+          "url": "",
+          "version": null,
+          "updateDate": "14 Jul, 2021"
+        }
+      ]
     },
     "compound_application_type_chebi": {
       "label": "Application type",
       "description": "Classification based on the application types, such as pharmaceutical or pesticide from ChEBI",
-      "data": "https://integbio.jp/togosite/sparqlist/api/compound_application_type_chebi",
+      "api": "https://integbio.jp/togosite/sparqlist/api/compound_application_type_chebi",
       "idType": "chebi",
-      "dataSource": {
-        "label": "",
-        "url": "",
-        "updateDate": ""
-      }
+      "data": [
+        {
+          "label": "",
+          "url": "",
+          "version": null,
+          "updateDate": "14 Jul, 2021"
+        }
+      ]
     },
     "compound_action_type_chembl": {
       "label": "Action type",
       "description": "Classification based on the mechanism of action, such as an inhibitor or an antagonist from ChEMBL",
-      "data": "https://integbio.jp/togosite/sparqlist/api/compound_action_type_chembl",
+      "api": "https://integbio.jp/togosite/sparqlist/api/compound_action_type_chembl",
       "idType": "chembl_compound",
-      "dataSource": {
-        "label": "",
-        "url": "",
-        "updateDate": ""
-      }
+      "data": [
+        {
+          "label": "ChEMBL-RDF",
+          "url": "http://ftp.ebi.ac.uk/pub/databases/chembl/ChEMBL-RDF/",
+          "version": null,
+          "updateDate": "14 Jul, 2021"
+        }
+      ]
     },
     "compound_biological_role_chebi": {
       "label": "Biological role",
       "description": "Classification based on the biological roles, such as inhibitor or antimicrobial agent from ChEBI",
-      "data": "https://integbio.jp/togosite/sparqlist/api/compound_biological_role_chebi",
+      "api": "https://integbio.jp/togosite/sparqlist/api/compound_biological_role_chebi",
       "idType": "chebi",
-      "dataSource": {
-        "label": "",
-        "url": "",
-        "updateDate": ""
-      }
+      "data": [
+        {
+          "label": "",
+          "url": "",
+          "version": null,
+          "updateDate": "14 Jul, 2021"
+        }
+      ]
     },
     "compound_drug_indication_mesh_chembl": {
       "label": "Drug indication",
       "description": "Classification of diseases for which drugs are indicated, based on hierarchical data using MeSH, a life science thesaurus from ChEMBL",
-      "data": "https://integbio.jp/togosite/sparqlist/api/compound_drug_indication_mesh_chembl",
+      "api": "https://integbio.jp/togosite/sparqlist/api/compound_drug_indication_mesh_chembl",
       "idType": "chembl_compound",
-      "dataSource": {
-        "label": "",
-        "url": "",
-        "updateDate": ""
-      }
+      "data": [
+        {
+          "label": "ChEMBL-RDF",
+          "url": "http://ftp.ebi.ac.uk/pub/databases/chembl/ChEMBL-RDF/",
+          "version": null,
+          "updateDate": "14 Jul, 2021"
+        }
+      ]
     },
     "compound_drug_development_phase_chembl": {
       "label": "Drug development phase",
       "description": "Classification based on the drug's development phase (research stage, phase I-III, and post-launch) from ChEMBL",
-      "data": "https://integbio.jp/togosite/sparqlist/api/compound_drug_development_phase_chembl",
+      "api": "https://integbio.jp/togosite/sparqlist/api/compound_drug_development_phase_chembl",
       "idType": "chembl_compound",
-      "dataSource": {
-        "label": "",
-        "url": "",
-        "updateDate": ""
-      }
+      "data": [
+        {
+          "label": "ChEMBL-RDF",
+          "url": "http://ftp.ebi.ac.uk/pub/databases/chembl/ChEMBL-RDF/",
+          "version": null,
+          "updateDate": "14 Jul, 2021"
+        }
+      ]
     },
     "compound_atc_classification_pubchem": {
       "label": "PubChem ATC classification",
       "description": "Classification of a medicine (in PubChem) according to its medicinal properties (WHO ATC Code)",
-      "data": "https://integbio.jp/togosite/sparqlist/api/compound_atc_classification_pubchem",
+      "api": "https://integbio.jp/togosite/sparqlist/api/compound_atc_classification_pubchem",
       "idType": "pubchem_compound",
-      "dataSource": {
-        "label": "",
-        "url": "",
-        "updateDate": ""
-      }
+      "data": [
+        {
+          "label": "",
+          "url": "",
+          "version": null,
+          "updateDate": "14 Jul, 2021"
+        }
+      ]
     },
     "compound_atc_classification_chembl": {
       "label": "ChEMBL ATC classification",
       "description": "Classification of a medicine (in ChEMBL) according to its medicinal properties (WHO ATC Code)",
-      "data": "https://integbio.jp/togosite/sparqlist/api/compound_atc_classification_chembl",
+      "api": "https://integbio.jp/togosite/sparqlist/api/compound_atc_classification_chembl",
       "idType": "chembl_compound",
-      "dataSource": {
-        "label": "",
-        "url": "",
-        "updateDate": ""
-      }
+      "data": [
+        {
+          "label": "",
+          "url": "",
+          "version": null,
+          "updateDate": "14 Jul, 2021"
+        }
+      ]
     },
     "disease_diseases_mondo": {
       "label": "Diseases in Mondo",
       "description": "Subcategories in the Disease or disorder category in the Mondo Disease Ontology (Mondo)",
-      "data": "https://integbio.jp/togosite/sparqlist/api/disease_diseases_mondo",
+      "api": "https://integbio.jp/togosite/sparqlist/api/disease_diseases_mondo",
       "idType": "mondo",
-      "dataSource": {
-        "label": "",
-        "url": "",
-        "updateDate": ""
-      }
+      "data": [
+        {
+          "label": "Mondo Disease Ontology (Mondo)",
+          "url": "https://mondo.monarchinitiative.org/",
+          "version": null,
+          "updateDate": "14 Jul, 2021"
+        }
+      ]
     },
     "disease_diseases_mesh": {
       "label": "Diseases in MeSH",
       "description": "Subcategories in the Disease category in Medical Subject Headings (MeSH)",
-      "data": "https://integbio.jp/togosite/sparqlist/api/disease_diseases_mesh",
+      "api": "https://integbio.jp/togosite/sparqlist/api/disease_diseases_mesh",
       "idType": "mesh",
-      "dataSource": {
-        "label": "",
-        "url": "",
-        "updateDate": ""
-      }
+      "data": [
+        {
+          "label": "Medical Subject Headings (MeSH)",
+          "url": "https://www.nlm.nih.gov/mesh/meshhome.html",
+          "version": null,
+          "updateDate": "14 Jul, 2021"
+        }
+      ]
     },
     "disease_diseases_nando": {
       "label": "Diseases in NANDO",
       "description": "Japanese rare and intractable disease categories in the Nanbyo Disease Ontology (NANDO)",
-      "data": "https://integbio.jp/togosite/sparqlist/api/disease_diseases_nando",
+      "api": "https://integbio.jp/togosite/sparqlist/api/disease_diseases_nando",
       "idType": "nando",
-      "dataSource": {
-        "label": "",
-        "url": "",
-        "updateDate": ""
-      }
+      "data": [
+        {
+          "label": "Nanbyo Disease Ontology (NANDO)",
+          "url": "http://nanbyodata.jp/ontology/nando",
+          "version": null,
+          "updateDate": "14 Jul, 2021"
+        }
+      ]
     },
     "disease_related_dbs_mondo": {
       "label": "Cross referenced disease DBs in Mondo",
       "description": "Number of entries linked to Mondo in each of approx. 70 disease related databases from database cross reference in Mondo",
-      "data": "https://integbio.jp/togosite/sparqlist/api/disease_related_dbs_mondo",
+      "api": "https://integbio.jp/togosite/sparqlist/api/disease_related_dbs_mondo",
       "idType": "mondo",
-      "dataSource": {
-        "label": "",
-        "url": "",
-        "updateDate": ""
-      }
+      "data": [
+        {
+          "label": "Mondo Disease Ontology (Mondo)",
+          "url": "https://mondo.monarchinitiative.org/",
+          "version": null,
+          "updateDate": "14 Jul, 2021"
+        }
+      ]
     },
     "disease_phenotypic_abnormality_hpo": {
       "label": "Phenotypic abnormality",
       "description": "Classification the subcategories of the Phenotypic abnormality categories of the Human Phenotype Ontology (HPO)",
-      "data": "https://integbio.jp/togosite/sparqlist/api/disease_phenotypic_abnormality_hpo",
+      "api": "https://integbio.jp/togosite/sparqlist/api/disease_phenotypic_abnormality_hpo",
       "idType": "hp",
-      "dataSource": {
-        "label": "",
-        "url": "",
-        "updateDate": ""
-      }
+      "data": [
+        {
+          "label": "Human Phenotype Ontology (HPO)",
+          "url": "https://hpo.jax.org/app/browse/term/HP:0000118",
+          "version": null,
+          "updateDate": "14 Jul, 2021"
+        }
+      ]
     },
     "variant_gwas_togovar": {
       "label": "GWAS",
       "description": "Classification of statistically significant variants in genome-wide association studies (GWAS) based on associated traits. Obtained from GWAS catalog via TogoVar",
-      "data": "https://integbio.jp/togosite/sparqlist/api/variant_gwas_togovar",
+      "api": "https://integbio.jp/togosite/sparqlist/api/variant_gwas_togovar",
       "idType": "togovar",
-      "dataSource": {
-        "label": "",
-        "url": "",
-        "updateDate": ""
-      }
+      "data": [
+        {
+          "label": "GWAS Catalog All associations ",
+          "url": "https://www.ebi.ac.uk/gwas/docs/file-downloads",
+          "version": null,
+          "updateDate": "14 Jul, 2021"
+        }
+      ]
     },
     "variant_clinical_significance_togovar": {
       "label": "Clinical significance",
       "description": "Classification of variants according to their clinical significance, such as whether they are the cause of the disease or not. Obtained from ClinVar via TogoVar",
-      "data": "https://integbio.jp/togosite/sparqlist/api/variant_clinical_significance_togovar",
+      "api": "https://integbio.jp/togosite/sparqlist/api/variant_clinical_significance_togovar",
       "idType": "togovar",
-      "dataSource": {
-        "label": "",
-        "url": "",
-        "updateDate": ""
-      }
+      "data": [
+        {
+          "label": "TogoVar,ClinVar",
+          "url": "",
+          "version": null,
+          "updateDate": "14 Jul, 2021"
+        }
+      ]
     }
   },
   "idTypes": {

--- a/config/togosite-human/attributes.json
+++ b/config/togosite-human/attributes.json
@@ -34,10 +34,6 @@
         "protein_number_of_glycosylation_sites_uniprot",
         "protein_disease_related_proteins_uniprot",
         "protein_isolation_source_uniprot",
-        "protein_high_level_expression_in_tissues_hpa",
-        "protein_medium_level_expression_in_tissues_hpa",
-        "protein_low_level_expression_in_tissues_hpa",
-        "protein_no_expression_in_tissues_hpa",
         "protein_evidence_of_existence_nextprot"
       ]
     },
@@ -81,6 +77,14 @@
       ]
     },
     {
+      "id": "glycan",
+      "label": "Glycan",
+      "attributes": [
+        "glycan_mass_glycosmos",
+        "glycan_tissue_glycosmos"
+      ]
+    },
+    {
       "id": "disease",
       "label": "Disease",
       "attributes": [
@@ -111,7 +115,7 @@
           "label": "Ensembl",
           "url": "http://nov2020.archive.ensembl.org/Homo_sapiens/Info/Index",
           "version": null,
-          "updateDate": "14 Jul, 2021"
+          "updateDate": "2020-10-29"
         }
       ]
     },
@@ -125,7 +129,7 @@
           "label": "Ensembl human release 102",
           "url": "http://nov2020.archive.ensembl.org/Homo_sapiens/Info/Index",
           "version": null,
-          "updateDate": "14 Jul, 2021"
+          "updateDate": "2020-10-29"
         }
       ]
     },
@@ -139,7 +143,7 @@
           "label": "Ensembl human release 102",
           "url": "http://nov2020.archive.ensembl.org/Homo_sapiens/Info/Index",
           "version": null,
-          "updateDate": "14 Jul, 2021"
+          "updateDate": "2020-10-29"
         }
       ]
     },
@@ -153,7 +157,7 @@
           "label": "HomoloGene",
           "url": "https://www.ncbi.nlm.nih.gov/homologene/statistics/",
           "version": null,
-          "updateDate": "14 Jul, 2021"
+          "updateDate": "2021-03-12"
         }
       ]
     },
@@ -167,7 +171,7 @@
           "label": "HomoloGene",
           "url": "https://www.ncbi.nlm.nih.gov/homologene/statistics/",
           "version": null,
-          "updateDate": "14 Jul, 2021"
+          "updateDate": "2021-03-12"
         }
       ]
     },
@@ -181,7 +185,7 @@
           "label": "Calculations for tissue specificity of genechip human GSE7307 from RefEx",
           "url": "https://doi.org/10.6084/m9.figshare.4028700.v3",
           "version": null,
-          "updateDate": "14 Jul, 2021"
+          "updateDate": "2021-03-12"
         }
       ]
     },
@@ -195,7 +199,7 @@
           "label": "Calculations for tissue specificity of genechip human GSE7307 from RefEx",
           "url": "https://doi.org/10.6084/m9.figshare.4028700.v3",
           "version": null,
-          "updateDate": "14 Jul, 2021"
+          "updateDate": "2021-03-12"
         }
       ]
     },
@@ -209,7 +213,7 @@
           "label": "Supplementary Table 1 of A systematic survey of human tissue-specific gene expression and splicing reveals new opportunities for therapeutic target identification and evaluation; R. Y. Yang et al.; bioRxiv 311563",
           "url": "https://doi.org/10.1101/311563",
           "version": null,
-          "updateDate": "14 Jul, 2021"
+          "updateDate": "2021-03-29"
         }
       ]
     },
@@ -223,7 +227,7 @@
           "label": "Supplementary Table 1 of A systematic survey of human tissue-specific gene expression and splicing reveals new opportunities for therapeutic target identification and evaluation; R. Y. Yang et al.; bioRxiv 311563",
           "url": "https://doi.org/10.1101/311563",
           "version": null,
-          "updateDate": "14 Jul, 2021"
+          "updateDate": "2021-03-29"
         }
       ]
     },
@@ -237,7 +241,7 @@
           "label": "HPA TSV",
           "url": "https://www.proteinatlas.org/about/download",
           "version": null,
-          "updateDate": "28 Jul, 2021"
+          "updateDate": "2021-07-28"
         }
       ]
     },
@@ -251,7 +255,7 @@
           "label": "HPA TSV",
           "url": "https://www.proteinatlas.org/about/download",
           "version": null,
-          "updateDate": "28 Jul, 2021"
+          "updateDate": "2021-07-28"
         }
       ]
     },
@@ -265,7 +269,7 @@
           "label": "ChIP-Atlas",
           "url": "http://dbarchive.biosciencedbc.jp/kyushu-u/hg38/target/",
           "version": null,
-          "updateDate": "14 Jul, 2021"
+          "updateDate": "2021-03-12"
         }
       ]
     },
@@ -279,7 +283,7 @@
           "label": "UniProt",
           "url": "https://www.uniprot.org/",
           "version": null,
-          "updateDate": "14 Jul, 2021"
+          "updateDate": "2021-06-17"
         }
       ]
     },
@@ -293,7 +297,7 @@
           "label": "Gene ontology cellular component annotation from UniProt",
           "url": "https://www.uniprot.org/",
           "version": null,
-          "updateDate": "14 Jul, 2021"
+          "updateDate": "2021-06-17"
         }
       ]
     },
@@ -307,7 +311,7 @@
           "label": "Gene ontology biological process annotation from UniProt",
           "url": "https://www.uniprot.org/",
           "version": null,
-          "updateDate": "14 Jul, 2021"
+          "updateDate": "2021-06-17"
         }
       ]
     },
@@ -321,7 +325,7 @@
           "label": "Gene ontology molecular function annotation from UniProt",
           "url": "https://www.uniprot.org/",
           "version": null,
-          "updateDate": "14 Jul, 2021"
+          "updateDate": "2021-06-17"
         }
       ]
     },
@@ -335,7 +339,7 @@
           "label": "Function from UniProt",
           "url": "https://www.uniprot.org/",
           "version": null,
-          "updateDate": "14 Jul, 2021"
+          "updateDate": "2021-06-17"
         }
       ]
     },
@@ -349,7 +353,7 @@
           "label": "Sequences from UniProt",
           "url": "https://www.uniprot.org/",
           "version": null,
-          "updateDate": "14 Jul, 2021"
+          "updateDate": "2021-06-17"
         }
       ]
     },
@@ -363,7 +367,7 @@
           "label": "Amino acid modifications from UniProt",
           "url": "https://www.uniprot.org/",
           "version": null,
-          "updateDate": "14 Jul, 2021"
+          "updateDate": "2021-06-17"
         }
       ]
     },
@@ -377,7 +381,7 @@
           "label": "Topology from UniProt",
           "url": "https://www.uniprot.org/",
           "version": null,
-          "updateDate": "14 Jul, 2021"
+          "updateDate": "2021-06-17"
         }
       ]
     },
@@ -391,7 +395,7 @@
           "label": "Amino acid modifications from UniProt",
           "url": "https://www.uniprot.org/",
           "version": null,
-          "updateDate": "14 Jul, 2021"
+          "updateDate": "2021-06-17"
         }
       ]
     },
@@ -405,7 +409,7 @@
           "label": "Amino acid modifications from UniProt",
           "url": "https://www.uniprot.org/",
           "version": null,
-          "updateDate": "14 Jul, 2021"
+          "updateDate": "2021-06-17"
         }
       ]
     },
@@ -419,7 +423,7 @@
           "label": "Pathology & Biotech from UniProt",
           "url": "https://www.uniprot.org/",
           "version": null,
-          "updateDate": "14 Jul, 2021"
+          "updateDate": "2021-06-17"
         }
       ]
     },
@@ -433,63 +437,7 @@
           "label": "Tissue from UniProt",
           "url": "https://www.uniprot.org/",
           "version": null,
-          "updateDate": "14 Jul, 2021"
-        }
-      ]
-    },
-    "protein_high_level_expression_in_tissues_hpa": {
-      "label": "Highly expressed in tissues (HPA)",
-      "description": "Tissues in which expression level of a gene is evaluated as \"High\" by HPA",
-      "api": "https://integbio.jp/togosite/sparqlist/api/protein_high_level_expression_in_tissues_hpa",
-      "idType": "ensembl_gene",
-      "data": [
-        {
-          "label": "HPA RDF",
-          "url": "https://www.proteinatlas.org/about/download",
-          "version": null,
-          "updateDate": "28 Jul, 2021"
-        }
-      ]
-    },
-    "protein_medium_level_expression_in_tissues_hpa": {
-      "label": "Intermediately expressed in tissues (HPA)",
-      "description": "Tissues in which expression level of a gene is evaluated as \"Medium\" by HPA",
-      "api": "https://integbio.jp/togosite/sparqlist/api/protein_medium_level_expression_in_tissues_hpa",
-      "idType": "ensembl_gene",
-      "data": [
-        {
-          "label": "HPA RDF",
-          "url": "https://www.proteinatlas.org/about/download",
-          "version": null,
-          "updateDate": "28 Jul, 2021"
-        }
-      ]
-    },
-    "protein_low_level_expression_in_tissues_hpa": {
-      "label": "Lowly expressed in tissues (HPA)",
-      "description": "Tissues in which expression level of a gene is evaluated as \"Low\" by HPA",
-      "api": "https://integbio.jp/togosite/sparqlist/api/protein_low_level_expression_in_tissues_hpa",
-      "idType": "ensembl_gene",
-      "data": [
-        {
-          "label": "HPA RDF",
-          "url": "https://www.proteinatlas.org/about/download",
-          "version": null,
-          "updateDate": "28 Jul, 2021"
-        }
-      ]
-    },
-    "protein_no_expression_in_tissues_hpa": {
-      "label": "Not expressed in tissues (HPA)",
-      "description": "Tissues in which expression level of a gene is evaluated as \"Not_detected\" by HPA",
-      "api": "https://integbio.jp/togosite/sparqlist/api/protein_no_expression_in_tissues_hpa",
-      "idType": "ensembl_gene",
-      "data": [
-        {
-          "label": "HPA RDF",
-          "url": "https://www.proteinatlas.org/about/download",
-          "version": null,
-          "updateDate": "28 Jul, 2021"
+          "updateDate": "2021-06-17"
         }
       ]
     },
@@ -503,7 +451,7 @@
           "label": "Expression from neXtProt",
           "url": "https://www.nextprot.org/",
           "version": null,
-          "updateDate": "14 Jul, 2021"
+          "updateDate": "2021-02-18"
         }
       ]
     },
@@ -517,7 +465,7 @@
           "label": "Structure from Uniprot",
           "url": "https://www.uniprot.org/help/structure_section",
           "version": null,
-          "updateDate": "14 Jul, 2021"
+          "updateDate": "2021-06-17"
         }
       ]
     },
@@ -531,7 +479,7 @@
           "label": "'Helix' entities counted in each entry of PDB",
           "url": "https://data.pdbj.org/pdbjplus/data/pdb/rdf/",
           "version": null,
-          "updateDate": "14 Jul, 2021"
+          "updateDate": "2021-08-19"
         }
       ]
     },
@@ -545,7 +493,7 @@
           "label": "'Sheet' entities counted in each entry of PDB",
           "url": "https://data.pdbj.org/pdbjplus/data/pdb/rdf/",
           "version": null,
-          "updateDate": "14 Jul, 2021"
+          "updateDate": "2021-08-19"
         }
       ]
     },
@@ -559,7 +507,7 @@
           "label": "Entity from PDB",
           "url": "https://data.pdbj.org/pdbjplus/data/pdb/rdf/",
           "version": null,
-          "updateDate": "14 Jul, 2021"
+          "updateDate": "2021-08-19"
         }
       ]
     },
@@ -573,7 +521,7 @@
           "label": "Entity from PDB",
           "url": "https://data.pdbj.org/pdbjplus/data/pdb/rdf/",
           "version": null,
-          "updateDate": "14 Jul, 2021"
+          "updateDate": "2021-08-19"
         }
       ]
     },
@@ -587,7 +535,7 @@
           "label": "Experimental method from PDB",
           "url": "https://data.pdbj.org/pdbjplus/data/pdb/rdf/",
           "version": null,
-          "updateDate": "14 Jul, 2021"
+          "updateDate": "2021-08-19"
         }
       ]
     },
@@ -601,7 +549,7 @@
           "label": "Crystallization Conditions from PDB",
           "url": "https://data.pdbj.org/pdbjplus/data/pdb/rdf/",
           "version": null,
-          "updateDate": "14 Jul, 2021"
+          "updateDate": "2021-08-19"
         }
       ]
     },
@@ -615,7 +563,7 @@
           "label": "Crystallization Conditions from PDB",
           "url": "https://data.pdbj.org/pdbjplus/data/pdb/rdf/",
           "version": null,
-          "updateDate": "14 Jul, 2021"
+          "updateDate": "2021-08-19"
         }
       ]
     },
@@ -629,7 +577,7 @@
           "label": "Reactome",
           "url": "https://reactome.org/download-data",
           "version": null,
-          "updateDate": "14 Jul, 2021"
+          "updateDate": "2021-03-05"
         }
       ]
     },
@@ -643,7 +591,7 @@
           "label": "Reactome",
           "url": "https://reactome.org/download-data",
           "version": null,
-          "updateDate": "14 Jul, 2021"
+          "updateDate": "2021-03-05"
         }
       ]
     },
@@ -657,7 +605,7 @@
           "label": "Interaction from UniProt",
           "url": "https://www.uniprot.org/help/interaction_section",
           "version": null,
-          "updateDate": "14 Jul, 2021"
+          "updateDate": "2021-06-17"
         }
       ]
     },
@@ -671,7 +619,7 @@
           "label": "Target protein from ChEMBL-RDF 28.0 against all UniProt entries",
           "url": "http://ftp.ebi.ac.uk/pub/databases/chembl/ChEMBL-RDF/",
           "version": null,
-          "updateDate": "14 Jul, 2021"
+          "updateDate": "2021-03-01"
         }
       ]
     },
@@ -685,7 +633,7 @@
           "label": "ChEMBL-RDF",
           "url": "http://ftp.ebi.ac.uk/pub/databases/chembl/ChEMBL-RDF/",
           "version": null,
-          "updateDate": "14 Jul, 2021"
+          "updateDate": "2021-03-01"
         }
       ]
     },
@@ -696,10 +644,10 @@
       "idType": "chebi",
       "data": [
         {
-          "label": "",
-          "url": "",
+          "label": "Chemical role from ChEBI",
+          "url": "https://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:51086",
           "version": null,
-          "updateDate": "14 Jul, 2021"
+          "updateDate": "2021-08-01"
         }
       ]
     },
@@ -710,10 +658,10 @@
       "idType": "chebi",
       "data": [
         {
-          "label": "",
-          "url": "",
+          "label": "Application type from ChEBI",
+          "url": "https://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:33232",
           "version": null,
-          "updateDate": "14 Jul, 2021"
+          "updateDate": "2021-08-01"
         }
       ]
     },
@@ -727,7 +675,7 @@
           "label": "ChEMBL-RDF",
           "url": "http://ftp.ebi.ac.uk/pub/databases/chembl/ChEMBL-RDF/",
           "version": null,
-          "updateDate": "14 Jul, 2021"
+          "updateDate": "2021-03-01"
         }
       ]
     },
@@ -738,10 +686,10 @@
       "idType": "chebi",
       "data": [
         {
-          "label": "",
-          "url": "",
+          "label": "Biological role from ChEBI ",
+          "url": "https://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:24432",
           "version": null,
-          "updateDate": "14 Jul, 2021"
+          "updateDate": "2021-08-01"
         }
       ]
     },
@@ -755,7 +703,7 @@
           "label": "ChEMBL-RDF",
           "url": "http://ftp.ebi.ac.uk/pub/databases/chembl/ChEMBL-RDF/",
           "version": null,
-          "updateDate": "14 Jul, 2021"
+          "updateDate": "2021-03-01"
         }
       ]
     },
@@ -769,7 +717,7 @@
           "label": "ChEMBL-RDF",
           "url": "http://ftp.ebi.ac.uk/pub/databases/chembl/ChEMBL-RDF/",
           "version": null,
-          "updateDate": "14 Jul, 2021"
+          "updateDate": "2021-03-01"
         }
       ]
     },
@@ -801,6 +749,34 @@
         }
       ]
     },
+    "glycan_mass_glycosmos": {
+      "label": "Molecular mass of glycans",
+      "description": "Molecular weight of the glycans from GlyCosmos",
+      "api": "https://integbio.jp/togosite/sparqlist/api/glycan_mass_glycosmos",
+      "idType": "glytoucan",
+      "data": [
+        {
+          "label": "GlyCosmos",
+          "url": "https://glycosmos.org/data",
+          "version": null,
+          "updateDate": "N/A"
+        }
+      ]
+    },
+    "glycan_tissue_glycosmos": {
+      "label": "Tissues",
+      "description": "Tissues where glycans are expressed",
+      "api": "https://integbio.jp/togosite/sparqlist/api/glycan_tissue_glycosmos",
+      "idType": "glytoucan",
+      "data": [
+        {
+          "label": "GlyCosmos",
+          "url": "https://glycosmos.org/data",
+          "version": null,
+          "updateDate": "N/A"
+        }
+      ]
+    },
     "disease_diseases_mondo": {
       "label": "Diseases in Mondo",
       "description": "Subcategories in the Disease or disorder category in the Mondo Disease Ontology (Mondo)",
@@ -811,7 +787,7 @@
           "label": "Mondo Disease Ontology (Mondo)",
           "url": "https://mondo.monarchinitiative.org/",
           "version": null,
-          "updateDate": "14 Jul, 2021"
+          "updateDate": "2021-08-11"
         }
       ]
     },
@@ -825,7 +801,7 @@
           "label": "Medical Subject Headings (MeSH)",
           "url": "https://www.nlm.nih.gov/mesh/meshhome.html",
           "version": null,
-          "updateDate": "14 Jul, 2021"
+          "updateDate": "2021-03-05"
         }
       ]
     },
@@ -839,7 +815,7 @@
           "label": "Nanbyo Disease Ontology (NANDO)",
           "url": "http://nanbyodata.jp/ontology/nando",
           "version": null,
-          "updateDate": "14 Jul, 2021"
+          "updateDate": "2021-08-05"
         }
       ]
     },
@@ -853,7 +829,7 @@
           "label": "Mondo Disease Ontology (Mondo)",
           "url": "https://mondo.monarchinitiative.org/",
           "version": null,
-          "updateDate": "14 Jul, 2021"
+          "updateDate": "2021-06-23"
         }
       ]
     },
@@ -867,7 +843,7 @@
           "label": "Human Phenotype Ontology (HPO)",
           "url": "https://hpo.jax.org/app/browse/term/HP:0000118",
           "version": null,
-          "updateDate": "14 Jul, 2021"
+          "updateDate": "2021-02-17"
         }
       ]
     },
@@ -881,7 +857,7 @@
           "label": "GWAS Catalog All associations ",
           "url": "https://www.ebi.ac.uk/gwas/docs/file-downloads",
           "version": null,
-          "updateDate": "14 Jul, 2021"
+          "updateDate": "2021-03-25"
         }
       ]
     },
@@ -892,10 +868,10 @@
       "idType": "togovar",
       "data": [
         {
-          "label": "TogoVar,ClinVar",
-          "url": "",
+          "label": "ClinVar",
+          "url": "https://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/",
           "version": null,
-          "updateDate": "14 Jul, 2021"
+          "updateDate": "2021-08-05"
         }
       ]
     }
@@ -913,6 +889,7 @@
         "chebi": "https://api.togoid.jp/convert?format=json&route=ensembl_gene,chebi",
         "chembl_compound": "https://api.togoid.jp/convert?format=json&route=ensembl_gene,chembl_compound",
         "pubchem_compound": "https://api.togoid.jp/convert?format=json&route=ensembl_gene,pubchem_compound",
+        "glytoucan": "https://api.togoid.jp/convert?format=json&route=ensembl_gene,glytoucan",
         "mondo": "https://api.togoid.jp/convert?format=json&route=ensembl_gene,mondo",
         "mesh": "https://api.togoid.jp/convert?format=json&route=ensembl_gene,mesh",
         "nando": "https://api.togoid.jp/convert?format=json&route=ensembl_gene,nando",
@@ -932,6 +909,7 @@
         "chebi": "https://api.togoid.jp/convert?format=json&route=ensembl_transcript,chebi",
         "chembl_compound": "https://api.togoid.jp/convert?format=json&route=ensembl_transcript,chembl_compound",
         "pubchem_compound": "https://api.togoid.jp/convert?format=json&route=ensembl_transcript,pubchem_compound",
+        "glytoucan": "https://api.togoid.jp/convert?format=json&route=ensembl_transcript,glytoucan",
         "mondo": "https://api.togoid.jp/convert?format=json&route=ensembl_transcript,mondo",
         "mesh": "https://api.togoid.jp/convert?format=json&route=ensembl_transcript,mesh",
         "nando": "https://api.togoid.jp/convert?format=json&route=ensembl_transcript,nando",
@@ -951,6 +929,7 @@
         "chebi": "https://api.togoid.jp/convert?format=json&route=ncbigene,chebi",
         "chembl_compound": "https://api.togoid.jp/convert?format=json&route=ncbigene,chembl_compound",
         "pubchem_compound": "https://api.togoid.jp/convert?format=json&route=ncbigene,pubchem_compound",
+        "glytoucan": "https://api.togoid.jp/convert?format=json&route=ncbigene,glytoucan",
         "mondo": "https://api.togoid.jp/convert?format=json&route=ncbigene,mondo",
         "mesh": "https://api.togoid.jp/convert?format=json&route=ncbigene,mesh",
         "nando": "https://api.togoid.jp/convert?format=json&route=ncbigene,nando",
@@ -970,6 +949,7 @@
         "chebi": "https://api.togoid.jp/convert?format=json&route=uniprot,chebi",
         "chembl_compound": "https://api.togoid.jp/convert?format=json&route=uniprot,chembl_compound",
         "pubchem_compound": "https://api.togoid.jp/convert?format=json&route=uniprot,pubchem_compound",
+        "glytoucan": "https://api.togoid.jp/convert?format=json&route=uniprot,glytoucan",
         "mondo": "https://api.togoid.jp/convert?format=json&route=uniprot,mondo",
         "mesh": "https://api.togoid.jp/convert?format=json&route=uniprot,mesh",
         "nando": "https://api.togoid.jp/convert?format=json&route=uniprot,nando",
@@ -989,6 +969,7 @@
         "chebi": "https://api.togoid.jp/convert?format=json&route=pdb,chebi",
         "chembl_compound": "https://api.togoid.jp/convert?format=json&route=pdb,chembl_compound",
         "pubchem_compound": "https://api.togoid.jp/convert?format=json&route=pdb,pubchem_compound",
+        "glytoucan": "https://api.togoid.jp/convert?format=json&route=pdb,glytoucan",
         "mondo": "https://api.togoid.jp/convert?format=json&route=pdb,mondo",
         "mesh": "https://api.togoid.jp/convert?format=json&route=pdb,mesh",
         "nando": "https://api.togoid.jp/convert?format=json&route=pdb,nando",
@@ -1008,6 +989,7 @@
         "pdb": "https://api.togoid.jp/convert?format=json&route=chebi,pdb",
         "chembl_compound": "https://api.togoid.jp/convert?format=json&route=chebi,chembl_compound",
         "pubchem_compound": "https://api.togoid.jp/convert?format=json&route=chebi,pubchem_compound",
+        "glytoucan": "https://api.togoid.jp/convert?format=json&route=chebi,glytoucan",
         "mondo": "https://api.togoid.jp/convert?format=json&route=chebi,mondo",
         "mesh": "https://api.togoid.jp/convert?format=json&route=chebi,mesh",
         "nando": "https://api.togoid.jp/convert?format=json&route=chebi,nando",
@@ -1027,6 +1009,7 @@
         "pdb": "https://api.togoid.jp/convert?format=json&route=chembl_compound,pdb",
         "chebi": "https://api.togoid.jp/convert?format=json&route=chembl_compound,chebi",
         "pubchem_compound": "https://api.togoid.jp/convert?format=json&route=chembl_compound,pubchem_compound",
+        "glytoucan": "https://api.togoid.jp/convert?format=json&route=chembl_compound,glytoucan",
         "mondo": "https://api.togoid.jp/convert?format=json&route=chembl_compound,mondo",
         "mesh": "https://api.togoid.jp/convert?format=json&route=chembl_compound,mesh",
         "nando": "https://api.togoid.jp/convert?format=json&route=chembl_compound,nando",
@@ -1046,11 +1029,32 @@
         "pdb": "https://api.togoid.jp/convert?format=json&route=pubchem_compound,pdb",
         "chebi": "https://api.togoid.jp/convert?format=json&route=pubchem_compound,chebi",
         "chembl_compound": "https://api.togoid.jp/convert?format=json&route=pubchem_compound,chembl_compound",
+        "glytoucan": "https://api.togoid.jp/convert?format=json&route=pubchem_compound,glytoucan",
         "mondo": "https://api.togoid.jp/convert?format=json&route=pubchem_compound,mondo",
         "mesh": "https://api.togoid.jp/convert?format=json&route=pubchem_compound,mesh",
         "nando": "https://api.togoid.jp/convert?format=json&route=pubchem_compound,nando",
         "hp": "https://api.togoid.jp/convert?format=json&route=pubchem_compound,hp",
         "togovar": "https://api.togoid.jp/convert?format=json&route=pubchem_compound,togovar"
+      }
+    },
+    "glytoucan": {
+      "label": "GlyTouCan",
+      "template": "https://raw.githubusercontent.com/dbcls/togosite/develop/config/togosite-human/templates/glytoucan.hbs",
+      "target": true,
+      "conversion": {
+        "ensembl_gene": "https://api.togoid.jp/convert?format=json&route=glytoucan,ensembl_gene",
+        "ensembl_transcript": "https://api.togoid.jp/convert?format=json&route=glytoucan,ensembl_transcript",
+        "ncbigene": "https://api.togoid.jp/convert?format=json&route=glytoucan,ncbigene",
+        "uniprot": "https://api.togoid.jp/convert?format=json&route=glytoucan,uniprot",
+        "pdb": "https://api.togoid.jp/convert?format=json&route=glytoucan,pdb",
+        "chebi": "https://api.togoid.jp/convert?format=json&route=glytoucan,chebi",
+        "chembl_compound": "https://api.togoid.jp/convert?format=json&route=glytoucan,chembl_compound",
+        "pubchem_compound": "https://api.togoid.jp/convert?format=json&route=glytoucan,pubchem_compound",
+        "mondo": "https://api.togoid.jp/convert?format=json&route=glytoucan,mondo",
+        "mesh": "https://api.togoid.jp/convert?format=json&route=glytoucan,mesh",
+        "nando": "https://api.togoid.jp/convert?format=json&route=glytoucan,nando",
+        "hp": "https://api.togoid.jp/convert?format=json&route=glytoucan,hp",
+        "togovar": "https://api.togoid.jp/convert?format=json&route=glytoucan,togovar"
       }
     },
     "mondo": {
@@ -1066,6 +1070,7 @@
         "chebi": "https://api.togoid.jp/convert?format=json&route=mondo,chebi",
         "chembl_compound": "https://api.togoid.jp/convert?format=json&route=mondo,chembl_compound",
         "pubchem_compound": "https://api.togoid.jp/convert?format=json&route=mondo,pubchem_compound",
+        "glytoucan": "https://api.togoid.jp/convert?format=json&route=mondo,glytoucan",
         "mesh": "https://api.togoid.jp/convert?format=json&route=mondo,mesh",
         "nando": "https://api.togoid.jp/convert?format=json&route=mondo,nando",
         "hp": "https://api.togoid.jp/convert?format=json&route=mondo,hp",
@@ -1085,6 +1090,7 @@
         "chebi": "https://api.togoid.jp/convert?format=json&route=mesh,chebi",
         "chembl_compound": "https://api.togoid.jp/convert?format=json&route=mesh,chembl_compound",
         "pubchem_compound": "https://api.togoid.jp/convert?format=json&route=mesh,pubchem_compound",
+        "glytoucan": "https://api.togoid.jp/convert?format=json&route=mesh,glytoucan",
         "mondo": "https://api.togoid.jp/convert?format=json&route=mesh,mondo",
         "nando": "https://api.togoid.jp/convert?format=json&route=mesh,nando",
         "hp": "https://api.togoid.jp/convert?format=json&route=mesh,hp",
@@ -1104,6 +1110,7 @@
         "chebi": "https://api.togoid.jp/convert?format=json&route=nando,chebi",
         "chembl_compound": "https://api.togoid.jp/convert?format=json&route=nando,chembl_compound",
         "pubchem_compound": "https://api.togoid.jp/convert?format=json&route=nando,pubchem_compound",
+        "glytoucan": "https://api.togoid.jp/convert?format=json&route=nando,glytoucan",
         "mondo": "https://api.togoid.jp/convert?format=json&route=nando,mondo",
         "mesh": "https://api.togoid.jp/convert?format=json&route=nando,mesh",
         "hp": "https://api.togoid.jp/convert?format=json&route=nando,hp",
@@ -1123,6 +1130,7 @@
         "chebi": "https://api.togoid.jp/convert?format=json&route=hp,chebi",
         "chembl_compound": "https://api.togoid.jp/convert?format=json&route=hp,chembl_compound",
         "pubchem_compound": "https://api.togoid.jp/convert?format=json&route=hp,pubchem_compound",
+        "glytoucan": "https://api.togoid.jp/convert?format=json&route=hp,glytoucan",
         "mondo": "https://api.togoid.jp/convert?format=json&route=hp,mondo",
         "mesh": "https://api.togoid.jp/convert?format=json&route=hp,mesh",
         "nando": "https://api.togoid.jp/convert?format=json&route=hp,nando",
@@ -1142,6 +1150,7 @@
         "chebi": "https://api.togoid.jp/convert?format=json&route=togovar,chebi",
         "chembl_compound": "https://api.togoid.jp/convert?format=json&route=togovar,chembl_compound",
         "pubchem_compound": "https://api.togoid.jp/convert?format=json&route=togovar,pubchem_compound",
+        "glytoucan": "https://api.togoid.jp/convert?format=json&route=togovar,glytoucan",
         "mondo": "https://api.togoid.jp/convert?format=json&route=togovar,mondo",
         "mesh": "https://api.togoid.jp/convert?format=json&route=togovar,mesh",
         "nando": "https://api.togoid.jp/convert?format=json&route=togovar,nando",

--- a/config/togosite-human/update.rb
+++ b/config/togosite-human/update.rb
@@ -8,25 +8,32 @@ class Property
     @data = property["data"]
     @data_source = property["dataSource"]
     @data_source_url = property["dataSourceUrl"]
+    @data_source_version = property["dataSourceUrlVersion"]
     @update = property["updatedAt"]
     @key = property["primaryKey"]
     @keyLabel = property["keyLabel"]
+    @view_method = property["viewMethod"]
   end
   attr_accessor :id, :label, :desc, :data, :data_source, :data_source_url, :update, :key, :keyLabel
 
   def attribute
-    {
+    attr = {
       id: @id,
       label: @label,
       description: @desc,
-      data: @data,
+      api: @data,
       idType: @key,
-      dataSource: {
-        label: @data_source,
-        url: @data_source_url,
-        updateDate: @update,
-      },
+      data: [
+        {
+          label: @data_source,
+          url: @data_source_url,
+          version: @data_source_version,
+          updateDate: @update,
+        },
+      ],
     }
+    attr[:viewMethod] = @viewMethod if @viewMethod
+    attr
   end
 end
 

--- a/config/togosite-human/update.rb
+++ b/config/togosite-human/update.rb
@@ -1,0 +1,84 @@
+require 'json'
+
+class Property
+  def initialize(property)
+    @id = property["propertyId"]
+    @label = property["label"]
+    @desc = property["description"]
+    @data = property["data"]
+    @data_source = property["dataSource"]
+    @data_source_url = property["dataSourceUrl"]
+    @update = property["updatedAt"]
+    @key = property["primaryKey"]
+    @keyLabel = property["keyLabel"]
+  end
+  attr_accessor :id, :label, :desc, :data, :data_source, :data_source_url, :update, :key, :keyLabel
+
+  def attribute
+    {
+      id: @id,
+      label: @label,
+      description: @desc,
+      data: @data,
+      idType: @key,
+      dataSource: {
+        label: @data_source,
+        url: @data_source_url,
+        updateDate: @update,
+      },
+    }
+  end
+end
+
+class Subject
+  def initialize(subject)
+    @id = subject["subjectId"]
+    @label = subject["subject"]
+    @properties = subject["properties"].map{|prop| Property.new(prop) }
+  end
+  attr_accessor :id, :label, :properties
+end
+
+properties = JSON.load(open("./properties.json").read)
+config = properties.each_with_object({}) do |subject, hash|
+  hash[:tracks] ||= []
+  hash[:attributes] ||= {}
+  hash[:idTypes] ||= {}
+
+  s = Subject.new(subject)
+
+  # identifiers
+  ids = s.properties.map{|p| { idType: p.key, label: p.keyLabel } }.uniq
+
+  ids.each do |id|
+    type = id.delete(:idType)
+    id[:template] = "https://raw.githubusercontent.com/dbcls/togosite/develop/config/togosite-human/templates/#{type}.hbs"
+    id[:target] = true
+
+    hash[:idTypes][type] = id
+  end
+
+  s.properties.each do |prop|
+    a = prop.attribute
+    id = a.delete(:id)
+    hash[:attributes][id] = a
+  end
+
+  # categories and attributes
+  h = {
+    id: s.id,
+    label: s.label,
+    attributes: s.properties.map{|p| p.id }
+  }
+
+  hash[:tracks] << h
+end
+
+id_types = config[:idTypes].keys
+id_types.each do |id|
+  config[:idTypes][id][:conversion] = id_types.each_with_object({}) do |oid, hash|
+    hash[oid] = "https://api.togoid.jp/convert?format=json&route=#{id},#{oid}" if id != oid
+  end
+end
+
+puts JSON(config)


### PR DESCRIPTION
カテゴリは飾りです、target もカテゴリではなく全部 id type にします、の全面改訂に伴って config の構造を整理。
subject, property という単語を完全に排除、代わりに category, attribute に。attribute が採用する id の型の表現が若干紛らわしかったので type になっている。id type のリストは identifiers として外出ししている。

データ構造的にはもうちょっと整理できそうだけど、人力で確認したり修正したりすることがままあるのでバランスを取ってみました。