### PR TITLE
removed hpa bars

### DIFF
--- a/config/togosite-human/properties.json
+++ b/config/togosite-human/properties.json
@@ -308,54 +308,6 @@
         "keyLabel": "UniProt"
       },
       {
-        "propertyId": "protein_high_level_expression_in_tissues_hpa",
-        "label": "Highly expressed in tissues (HPA)",
-        "description": "Tissues in which expression level of a gene is evaluated as \"High\" by HPA",
-        "data": "https://integbio.jp/togosite/sparqlist/api/protein_high_level_expression_in_tissues_hpa",
-        "dataSource": "HPA RDF",
-        "dataSourceUrl": "https://www.proteinatlas.org/about/download",
-        "dataSourceVersion": "N/A",
-        "updatedAt": "2021-07-28",
-        "primaryKey": "ensembl_gene",
-        "keyLabel": "Ensembl gene"
-      },
-      {
-        "propertyId": "protein_medium_level_expression_in_tissues_hpa",
-        "label": "Intermediately expressed in tissues (HPA)",
-        "description": "Tissues in which expression level of a gene is evaluated as \"Medium\" by HPA",
-        "data": "https://integbio.jp/togosite/sparqlist/api/protein_medium_level_expression_in_tissues_hpa",
-        "dataSource": "HPA RDF",
-        "dataSourceUrl": "https://www.proteinatlas.org/about/download",
-        "dataSourceVersion": "N/A",
-        "updatedAt": "2021-07-28",
-        "primaryKey": "ensembl_gene",
-        "keyLabel": "Ensembl gene"
-      },
-      {
-        "propertyId": "protein_low_level_expression_in_tissues_hpa",
-        "label": "Lowly expressed in tissues (HPA)",
-        "description": "Tissues in which expression level of a gene is evaluated as \"Low\" by HPA",
-        "data": "https://integbio.jp/togosite/sparqlist/api/protein_low_level_expression_in_tissues_hpa",
-        "dataSource": "HPA RDF",
-        "dataSourceUrl": "https://www.proteinatlas.org/about/download",
-        "dataSourceVersion": "N/A",
-        "updatedAt": "2021-07-28",
-        "primaryKey": "ensembl_gene",
-        "keyLabel": "Ensembl gene"
-      },
-      {
-        "propertyId": "protein_no_expression_in_tissues_hpa",
-        "label": "Not expressed in tissues (HPA)",
-        "description": "Tissues in which expression level of a gene is evaluated as \"Not_detected\" by HPA",
-        "data": "https://integbio.jp/togosite/sparqlist/api/protein_no_expression_in_tissues_hpa",
-        "dataSource": "HPA RDF",
-        "dataSourceUrl": "https://www.proteinatlas.org/about/download",
-        "dataSourceVersion": "N/A",
-        "updatedAt": "2021-07-28",
-        "primaryKey": "ensembl_gene",
-        "keyLabel": "Ensembl gene"
-      },
-      {
         "propertyId": "protein_evidence_of_existence_nextprot",
         "label" : "Evidence of existence",
         "description": "Classification by the basis of protein expression, such as whether it has been identified as a protein or transcript in Expression section from neXtProt",


### PR DESCRIPTION
データに不審点のある HPA 関係のバーを一旦削除。
ドキュメント作成用のスクリーンショットを撮る際、エラーとなっているバーがあるのはまずいという声があったので、一旦 dev-pro はきれいに見えるようにします。